### PR TITLE
CI: Run all tests on every PR

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -1,18 +1,11 @@
+---
 name: Apply
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/apply.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/bolt_spec.yaml
+++ b/.github/workflows/bolt_spec.yaml
@@ -1,19 +1,12 @@
+---
+
 name: BoltSpec
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/bolt_spec.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - lib/bolt_spec/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/docker_transport.yaml
+++ b/.github/workflows/docker_transport.yaml
@@ -1,3 +1,4 @@
+---
 name: Docker transport
 
 on:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,18 +1,11 @@
+---
 name: Linux
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/linux.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -1,18 +1,11 @@
+---
 name: Modules
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/modules.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - bolt_spec_spec/**
-      - lib/bolt/**
-      - modules/**
-      - rakelib/tests.rake
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/pwsh.yaml
+++ b/.github/workflows/pwsh.yaml
@@ -1,13 +1,11 @@
+---
 name: pwsh
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/pwsh.yaml
-      - pwsh_module/*
-      - lib/bolt/bolt_option_parser.rb
-      - rakelib/pwsh.rake
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -1,14 +1,11 @@
+---
 name: Schemas
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - lib/bolt/config/options.rb
-      - lib/bolt/config/transport/**
-      - lib/bolt/inventory/options.rb
-      - rakelib/schemas.rake
-      - schemas/*.json
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/ssh_transport.yaml
+++ b/.github/workflows/ssh_transport.yaml
@@ -1,18 +1,11 @@
+---
 name: SSH Transport
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/ssh_transport.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,18 +2,10 @@
 name: Windows
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/windows.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/.github/workflows/winrm_transport.yaml
+++ b/.github/workflows/winrm_transport.yaml
@@ -1,18 +1,11 @@
+---
 name: WinRM Transport
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/winrm_transport.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
This the past, the different jobs had filters and were only executed when specific files changed. This is error prone because we potentially forget to enable tests for specific changes. Since we've enough concurrent runners, we can run all jobs always.