### PR TITLE
ruby_smb: Allow 2.x

### DIFF
--- a/openbolt.gemspec
+++ b/openbolt.gemspec
@@ -63,7 +63,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "puppetfile-resolver", ">= 0.6.2", "< 1.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "r10k", ">= 3.10", "< 6"
-  spec.add_dependency "ruby_smb", "~> 1.0"
+  spec.add_dependency "ruby_smb", ">= 1.0", "< 3"
   spec.add_dependency "terminal-table", "~> 4.0"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.3"


### PR DESCRIPTION
In https://github.com/OpenVoxProject/openbolt/pull/58 we noticed that ruby_smb 3 is broken / not compatible with our codebase. Let's test 2.x.