### PR TITLE
CI: Switch windows builds to bigger runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -144,7 +144,7 @@ jobs:
       - rubocop_and_matrix
       - cache_modules
     name: WinRM Transport
-    runs-on: windows-latest
+    runs-on: openvox-windows-runner
     strategy:
       matrix:
         ruby: ${{ fromJSON(needs.rubocop_and_matrix.outputs.ruby) }}


### PR DESCRIPTION
The tests run for a very very long time. It makes sense to move them to a bigger runner. We've a cost limit of $50/month configured.