### PR TITLE
WinRM tests: disable fail-fast

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -146,6 +146,7 @@ jobs:
     name: WinRM Transport
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ${{ fromJSON(needs.rubocop_and_matrix.outputs.ruby) }}
     steps:


### PR DESCRIPTION
We never use that option, because it can hide issues in a pipeline