### PR TITLE
CI: Run docker transport tests on all changes

### DIFF
--- a/.github/workflows/docker_transport.yaml
+++ b/.github/workflows/docker_transport.yaml
@@ -2,18 +2,10 @@
 name: Docker transport
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/docker_transport.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
In the past, some tests were only executed when certain files changed. This doesn't make sense and hides errors. We update the CI configuration to run on each PR.