### PR TITLE
CI: Restart WinRM after Setup in ci.ps1

### DIFF
--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -156,3 +156,4 @@ Set-WSManQuickConfig -Force
 Set-WinRMHostConfiguration
 Test-WinRMConfiguration @User | Out-Null
 Add-Content -Path $ENV:GITHUB_ENV -Value "BOLT_WINRM_PASSWORD=$pass"
+Restart-Service WinRm


### PR DESCRIPTION
The old ones:
```
Validity
            Not Before: Jan 19 19:39:18 2023 GMT
            Not After : Oct 14 19:39:18 2025 GMT
```