### PR TITLE
renovate: Dont attach `dependencies` label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "addLabels": ["renovate", "puppet", "dependencies"],
+  "addLabels": ["renovate", "puppet"],
   "assigneesFromCodeOwners": true,
   "automerge": true,
   "automergeType": "pr",


### PR DESCRIPTION
PRs with this label are excluded from the CHANGELOG.md. dependabot attaches it for updated github actions. We don't want renovate to use the label, because we want to see module updates in the CHANGELOG.md.