### PR TITLE
Remove warning when using the plain gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,6 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 # Disable analytics when running in development
 ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 
-# Disable warning that Bolt may be installed as a gem
-ENV['BOLT_GEM'] = 'true'
-
 gemspec
 
 # Optional paint gem for rainbow outputter

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -411,7 +411,6 @@ module Bolt
           # FINALIZING SETUP
           #
 
-          check_gem_install
           warn_inventory_overrides_cli(config, options)
           submit_screen_view(analytics, config, inventory, options)
           options[:targets] = process_target_list(plugins, @rerun, options)
@@ -712,23 +711,6 @@ module Bolt
       end
 
       content
-    end
-
-    # Check and warn if Bolt is installed as a gem.
-    #
-    private def check_gem_install
-      if ENV['BOLT_GEM'].nil? && incomplete_install?
-        msg = <<~MSG.chomp
-          Bolt might be installed as a gem. To use Bolt reliably and with all of its
-          dependencies, uninstall the 'bolt' gem and install Bolt as a package:
-          https://puppet.com/docs/bolt/latest/bolt_installing.html
-
-          If you meant to install Bolt as a gem and want to disable this warning,
-          set the BOLT_GEM environment variable.
-        MSG
-
-        Bolt::Logger.warn("gem_install", msg)
-      end
     end
 
     # Print a fatal error. Print using the outputter if it's configured.

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -485,24 +485,6 @@ describe Bolt::CLI do
       end
     end
 
-    describe 'checking for gem install' do
-      it 'displays a warning when Bolt is installed as a gem' do
-        with_env_vars('BOLT_GEM' => nil) do
-          allow(cli).to receive(:incomplete_install?).and_return(true)
-          expect(Bolt::Logger).to receive(:warn).with('gem_install', anything)
-          cli.execute({})
-        end
-      end
-
-      it 'does not display a warning when BOLT_GEM is set' do
-        with_env_vars('BOLT_GEM' => 'true') do
-          allow(cli).to receive(:incomplete_install?).and_return(true)
-          cli.execute({})
-          expect(Bolt::Logger).not_to receive(:warn).with('gem_install', anything)
-        end
-      end
-    end
-
     describe 'analytics' do
       before(:each) do
         allow(cli).to receive(:submit_screen_view).and_call_original


### PR DESCRIPTION
We want to support this use case, so remove the warning.