### PR TITLE
Relax json gem requirement

### DIFF
--- a/openbolt.gemspec
+++ b/openbolt.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "ffi", ">= 1.9.25", "< 2.0.0"
   spec.add_dependency "hiera-eyaml", ">= 3.0.0", "< 5.0.0"
-  spec.add_dependency "json", "~> 2.12"
+  spec.add_dependency "json", "~> 2.6"
   spec.add_dependency "jwt", "~> 2.2"
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", ">= 0.6", "< 2.0"


### PR DESCRIPTION
To allow using the default json gem with Ruby 3.2.9 rather than having to ship it ourselves when we create packages.