### PR TITLE
docs: fix README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Modules Status](https://github.com/OpenVoxProject/openbolt/workflows/Modules/badge.svg?branch=main)](https://github.com/puppetlabs/bolt/actions)
-[![Linux Status](https://github.com/OpenVoxProject/openbolt/workflows/Linux/badge.svg?branch=main)](https://github.com/puppetlabs/bolt/actions)
-[![Windows Status](https://github.com/OpenVoxProject/openbolt/workflows/Windows/badge.svg?branch=main)](https://github.com/puppetlabs/bolt/actions)
+[![Modules Status](https://github.com/OpenVoxProject/openbolt/actions/workflows/modules.yaml/badge.svg?branch=main)](https://github.com/OpenVoxProject/openbolt/actions/workflows/modules.yaml)
+[![Build Status](https://github.com/OpenVoxProject/openbolt/actions/workflows/build.yml/badge.svg)](https://github.com/OpenVoxProject/openbolt/actions/workflows/build.yml)
 [![Version](https://img.shields.io/github/v/tag/OpenVoxProject/openbolt?label=version)](./CHANGELOG.md)
 [![Platforms](https://img.shields.io/badge/platforms-linux%20%7C%20windows%20%7C%20macos-lightgrey)](./documentation/bolt_installing.md)
 [![License](https://img.shields.io/github/license/OpenVoxProject/openbolt)](./LICENSE)


### PR DESCRIPTION
Quick fix to badges, working and pointing to OpenVox repo.

Btw, repo about is still "clone of puppetlabs/bolt", maybe it should be updated to something like "Community implementation of Puppet Bolt"?