### PR TITLE
Increase WinRM shell and user limits for CI

### DIFF
--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -156,4 +156,11 @@ Set-WSManQuickConfig -Force
 Set-WinRMHostConfiguration
 Test-WinRMConfiguration @User | Out-Null
 Add-Content -Path $ENV:GITHUB_ENV -Value "BOLT_WINRM_PASSWORD=$pass"
+Set-Item WSMan:\localhost\Plugin\microsoft.powershell\Quotas\MaxShells -Value 100
+Set-Item WSMan:\localhost\Plugin\microsoft.powershell\Quotas\MaxShellsPerUser -Value 100
+Set-Item WSMan:\localhost\Plugin\microsoft.powershell\Quotas\MaxProcessesPerShell -Value 100
+Set-Item WSMan:\localhost\Plugin\microsoft.powershell\Quotas\MaxConcurrentUsers -Value 100
+Set-Item WSMan:\localhost\Shell\MaxShellsPerUser -Value 100
+Set-Item WSMan:\localhost\Shell\MaxProcessesPerShell -Value 100
+Set-Item WSMan:\localhost\Shell\MaxConcurrentUsers -Value 100
 Restart-Service WinRm


### PR DESCRIPTION
The WinRM tests function by opening shells on localhost via WinRM. The defaults for processes, users, and shells per user may be getting exhausted in the course of running tests in parallel, resulting in the transient failures we've seen on PR checks. This bumps the limits up to a point where they hopefully should no longer be a problem.