### PR TITLE
Migrate bundled module specs from mocha to rspec-mocks/voxpupuli-test

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,6 +29,12 @@ Layout/ClosingHeredocIndentation:
     - 'spec/unit/pal_spec.rb'
     - 'spec/unit/util/format_spec.rb'
 
+# Offense count: 1
+# This cop supports safe autocorrection (--autocorrect).
+Layout/EmptyLineAfterGuardClause:
+  Exclude:
+    - 'rakelib/tests.rake'
+
 # Offense count: 660
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowMultipleStyles, EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.
@@ -43,7 +49,7 @@ Layout/HashAlignment:
 Layout/HeredocIndentation:
   Enabled: false
 
-# Offense count: 25
+# Offense count: 29
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, IndentationWidth.
 # SupportedStyles: aligned, indented
@@ -131,16 +137,6 @@ Lint/UselessConstantScoping:
 Lint/UselessOr:
   Exclude:
     - 'spec/integration/transport/winrm_spec.rb'
-
-# Offense count: 6
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, BlockForwardingName.
-# SupportedStyles: anonymous, explicit
-Naming/BlockForwarding:
-  Exclude:
-    - 'lib/bolt/executor.rb'
-    - 'lib/bolt/pal.rb'
-    - 'lib/bolt_spec/bolt_context.rb'
 
 # Offense count: 16
 # Configuration parameters: Mode, AllowedMethods, AllowedPatterns, AllowBangMethods, WaywardPredicates.
@@ -371,13 +367,13 @@ RSpec/ClassCheck:
 RSpec/ContextMethod:
   Enabled: false
 
-# Offense count: 332
+# Offense count: 339
 # Configuration parameters: Prefixes, AllowedPatterns.
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Enabled: false
 
-# Offense count: 110
+# Offense count: 113
 # Configuration parameters: IgnoredMetadata.
 RSpec/DescribeClass:
   Enabled: false
@@ -394,14 +390,14 @@ RSpec/DescribeSymbol:
     - 'spec/unit/plugin/module_spec.rb'
     - 'spec/unit/result_spec.rb'
 
-# Offense count: 266
+# Offense count: 267
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: SkipBlocks, EnforcedStyle, OnlyStaticConstants.
 # SupportedStyles: described_class, explicit
 RSpec/DescribedClass:
   Enabled: false
 
-# Offense count: 653
+# Offense count: 759
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:
   Max: 42
@@ -413,15 +409,18 @@ RSpec/ExampleLength:
 RSpec/ExampleWording:
   Enabled: false
 
-# Offense count: 31
+# Offense count: 35
 RSpec/ExpectInHook:
   Exclude:
+    - 'bolt-modules/boltlib/spec/functions/apply_prep_spec.rb'
+    - 'bolt-modules/boltlib/spec/functions/background_spec.rb'
+    - 'bolt-modules/boltlib/spec/functions/parallelize_spec.rb'
     - 'spec/bolt_spec/run_spec.rb'
     - 'spec/integration/logging_spec.rb'
     - 'spec/integration/modules/write_file_spec.rb'
     - 'spec/unit/cli_spec.rb'
 
-# Offense count: 276
+# Offense count: 354
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: implicit, each, example
@@ -433,14 +432,14 @@ RSpec/IdenticalEqualityAssertion:
   Exclude:
     - 'spec/unit/application_spec.rb'
 
-# Offense count: 371
+# Offense count: 369
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: single_line_only, single_statement_only, disallow, require_implicit
 RSpec/ImplicitSubject:
   Enabled: false
 
-# Offense count: 71
+# Offense count: 75
 # This cop supports unsafe autocorrection (--autocorrect-all).
 RSpec/IncludeExamples:
   Enabled: false
@@ -456,7 +455,7 @@ RSpec/IndexedLet:
     - 'spec/unit/result_set_spec.rb'
     - 'spec/unit/util/format_spec.rb'
 
-# Offense count: 259
+# Offense count: 265
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
   Enabled: false
@@ -489,7 +488,7 @@ RSpec/MatchArray:
     - 'spec/unit/target_spec.rb'
     - 'spec/unit/transport/ssh/connection_spec.rb'
 
-# Offense count: 332
+# Offense count: 709
 # Configuration parameters: .
 # SupportedStyles: have_received, receive
 RSpec/MessageSpies:
@@ -510,7 +509,7 @@ RSpec/MultipleDescribes:
     - 'spec/unit/analytics_spec.rb'
     - 'spec/unit/config/options_spec.rb'
 
-# Offense count: 649
+# Offense count: 648
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
   Max: 27
@@ -530,7 +529,7 @@ RSpec/NamedSubject:
     - 'spec/unit/transport/ssh/connection_spec.rb'
     - 'spec/unit/transport/ssh/exec_connection_spec.rb'
 
-# Offense count: 93
+# Offense count: 95
 # Configuration parameters: AllowedGroups.
 RSpec/NestedGroups:
   Max: 5
@@ -635,7 +634,7 @@ RSpec/SortMetadata:
     - 'spec/integration/apply_error_spec.rb'
     - 'spec/integration/inventory_spec.rb'
 
-# Offense count: 78
+# Offense count: 83
 # Configuration parameters: CustomTransform, IgnoreMethods, IgnoreMetadata, InflectorPath, EnforcedInflector.
 # SupportedInflectors: default, active_support
 RSpec/SpecFilePathFormat:
@@ -648,7 +647,7 @@ RSpec/SpecFilePathSuffix:
     - 'bolt-modules/boltlib/spec/functions/puppetdb_query.rb'
     - 'spec/integration/task_param.rb'
 
-# Offense count: 103
+# Offense count: 364
 RSpec/StubbedMock:
   Enabled: false
 
@@ -680,7 +679,7 @@ RSpec/VerifiedDoubleReference:
     - 'spec/unit/applicator_spec.rb'
     - 'spec/unit/inventory/group_spec.rb'
 
-# Offense count: 108
+# Offense count: 139
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:
   Enabled: false
@@ -697,7 +696,7 @@ RSpec/Yield:
     - 'spec/unit/application_spec.rb'
     - 'spec/unit/cli_spec.rb'
 
-# Offense count: 51
+# Offense count: 52
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle, AllowModifiersOnSymbols, AllowModifiersOnAttrs, AllowModifiersOnAliasMethod.
 # SupportedStyles: inline, group
@@ -727,7 +726,7 @@ Style/ArrayIntersect:
   Exclude:
     - 'bolt-modules/boltlib/lib/puppet/functions/download_file.rb'
 
-# Offense count: 238
+# Offense count: 263
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, AllowedMethods, AllowedPatterns, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.
 # SupportedStyles: line_count_based, semantic, braces_for_chaining, always_braces
@@ -745,7 +744,7 @@ Style/ConcatArrayLiterals:
     - 'spec/integration/cli/cli_spec.rb'
     - 'spec/unit/module_installer_spec.rb'
 
-# Offense count: 183
+# Offense count: 190
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
   Enabled: false
@@ -817,7 +816,7 @@ Style/FrozenStringLiteralComment:
     - '**/*.arb'
     - 'scripts/check_dependencies.rb'
 
-# Offense count: 95
+# Offense count: 96
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
 Style/GuardClause:
@@ -863,7 +862,7 @@ Style/HashExcept:
     - 'lib/bolt/plugin/cache.rb'
     - 'lib/bolt/result.rb'
 
-# Offense count: 213
+# Offense count: 216
 # This cop supports safe autocorrection (--autocorrect).
 Style/IfUnlessModifier:
   Enabled: false
@@ -894,7 +893,7 @@ Style/MutableConstant:
   Exclude:
     - 'lib/bolt/bolt_option_parser.rb'
 
-# Offense count: 27
+# Offense count: 28
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Strict, AllowedNumbers, AllowedPatterns.
 Style/NumericLiterals:
@@ -930,6 +929,14 @@ Style/OneClassPerFile:
 Style/OptionalBooleanParameter:
   Enabled: false
 
+# Offense count: 5
+# This cop supports unsafe autocorrection (--autocorrect-all).
+Style/PartitionInsteadOfDoubleSelect:
+  Exclude:
+    - 'spec/unit/transport/choria/bolt_tasks_spec.rb'
+    - 'spec/unit/transport/choria/shell_spec.rb'
+    - 'spec/unit/transport/choria_spec.rb'
+
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
@@ -938,7 +945,7 @@ Style/QuotedSymbols:
   Exclude:
     - 'spec/integration/transport/winrm_spec.rb'
 
-# Offense count: 13
+# Offense count: 15
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/ReduceToHash:
   Exclude:
@@ -949,6 +956,8 @@ Style/ReduceToHash:
     - 'lib/bolt/puppetdb/client.rb'
     - 'lib/bolt/result_set.rb'
     - 'lib/bolt/task.rb'
+    - 'lib/bolt/transport/choria/bolt_tasks.rb'
+    - 'lib/bolt/transport/choria/client.rb'
     - 'rakelib/schemas.rake'
     - 'spec/unit/executor_spec.rb'
 
@@ -1098,7 +1107,7 @@ Style/StderrPuts:
 Style/StringConcatenation:
   Enabled: false
 
-# Offense count: 3351
+# Offense count: 3408
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
 # SupportedStyles: single_quotes, double_quotes
@@ -1114,28 +1123,28 @@ Style/SuperArguments:
     - 'lib/bolt/error.rb'
     - 'lib/bolt_spec/plans/action_stubs/plan_stub.rb'
 
-# Offense count: 31
+# Offense count: 32
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, AllowSafeAssignment.
 # SupportedStyles: require_parentheses, require_no_parentheses, require_parentheses_when_complex
 Style/TernaryParentheses:
   Enabled: false
 
-# Offense count: 521
+# Offense count: 575
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyleForMultiline.
 # SupportedStylesForMultiline: comma, consistent_comma, diff_comma, no_comma
 Style/TrailingCommaInArguments:
   Enabled: false
 
-# Offense count: 227
+# Offense count: 268
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyleForMultiline.
 # SupportedStylesForMultiline: comma, consistent_comma, diff_comma, no_comma
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
 
-# Offense count: 1510
+# Offense count: 1558
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyleForMultiline.
 # SupportedStylesForMultiline: comma, consistent_comma, diff_comma, no_comma

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,12 +29,6 @@ Layout/ClosingHeredocIndentation:
     - 'spec/unit/pal_spec.rb'
     - 'spec/unit/util/format_spec.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Layout/EmptyLineAfterGuardClause:
-  Exclude:
-    - 'rakelib/tests.rake'
-
 # Offense count: 660
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowMultipleStyles, EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.

--- a/Gemfile
+++ b/Gemfile
@@ -31,9 +31,10 @@ gem "paint", "~> 2.2"
 
 group(:test) do
   gem "beaker-hostgenerator"
-  gem "mocha", '>= 1.4.0', '< 4'
   gem "rack-test", '>= 1', '< 3'
   gem 'rspec-github', require: false
+  gem 'rspec-puppet', '>= 5', require: false
+  gem 'puppet_fixtures', '>= 0.1', '< 3', require: false
 end
 
 group(:release, optional: true) do

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,7 @@ group(:test) do
   gem "beaker-hostgenerator"
   gem "rack-test", '>= 1', '< 3'
   gem 'rspec-github', require: false
-  gem 'rspec-puppet', '>= 5', require: false
-  gem 'puppet_fixtures', '>= 0.1', '< 3', require: false
+  gem 'voxpupuli-test', '~> 14.0', require: false
 end
 
 group(:release, optional: true) do

--- a/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
@@ -5,8 +5,6 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'add_facts' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('example') }

--- a/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
@@ -5,18 +5,20 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'add_facts' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('example') }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'should set a fact on a target' do
@@ -32,7 +34,7 @@ describe 'add_facts' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('add_facts')
+    expect(executor).to receive(:report_function_call).with('add_facts')
     is_expected.to run.with_params(target, {})
   end
 

--- a/bolt-modules/boltlib/spec/functions/add_to_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_to_group_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'bolt/inventory'
 
 describe 'add_to_group' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
@@ -12,11 +12,13 @@ describe 'add_to_group' do
   let(:group) { 'all' }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'should add a target to group' do
@@ -31,7 +33,7 @@ describe 'add_to_group' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('add_to_group')
+    expect(executor).to receive(:report_function_call).with('add_to_group')
     is_expected.to run.with_params(target, group)
   end
 

--- a/bolt-modules/boltlib/spec/functions/add_to_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_to_group_spec.rb
@@ -4,8 +4,6 @@ require 'spec_helper'
 require 'bolt/inventory'
 
 describe 'add_to_group' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('example') }

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -11,9 +11,9 @@ require 'bolt/target'
 require 'bolt/task'
 
 describe 'apply_prep' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
-  let(:applicator)    { mock('Bolt::Applicator') }
+  let(:applicator)    { double('Bolt::Applicator') }
   let(:config)        { Bolt::Config.default }
   let(:executor)      { Bolt::Executor.new }
   let(:plugins)       { Bolt::Plugin.new(config, nil) }
@@ -22,19 +22,21 @@ describe 'apply_prep' do
   let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    executor.stubs(:noop).returns(false)
+    allow(executor).to receive(:noop).and_return(false)
 
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory, apply_executor: applicator) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory, apply_executor: applicator)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'with targets' do
-    let(:hostnames)         { %w[a.b.com winrm://x.y.com pcp://foo] }
+    let(:hostnames)         { %w[a.b.com winrm://x.y.com remote://foo] }
     let(:targets)           { hostnames.map { |h| inventory.get_target(h) } }
-    let(:unknown_targets)   { targets.reject { |target| target.protocol == 'pcp' } }
+    let(:unknown_targets)   { targets.reject { |target| target.protocol == 'remote' } }
     let(:fact)              { { 'osfamily' => 'none' } }
     let(:custom_facts_task) { Bolt::Task.new('custom_facts_task') }
     let(:version_task)      { Bolt::Task.new('openvox_bootstrap::check') }
@@ -42,75 +44,75 @@ describe 'apply_prep' do
     let(:service_task)      { Bolt::Task.new('service') }
 
     before(:each) do
-      applicator.stubs(:build_plugin_tarball).returns(:tarball)
-      applicator.stubs(:custom_facts_task).returns(custom_facts_task)
+      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
+      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
       inventory.get_targets(targets)
       targets.each { |t| inventory.set_feature(t, 'puppet-agent', false) }
 
-      task1 = mock('version_task')
-      task1.stubs(:task_hash).returns('name' => 'openvox_bootstrap::check')
-      task1.stubs(:runnable_with?).returns(true)
-      Puppet::Pal::ScriptCompiler.any_instance.stubs(:task_signature).with('openvox_bootstrap::check').returns(task1)
-      task2 = mock('install_task')
-      task2.stubs(:task_hash).returns('name' => 'openvox_bootstrap::install')
-      task2.stubs(:runnable_with?).returns(true)
-      Puppet::Pal::ScriptCompiler.any_instance.stubs(:task_signature).with('openvox_bootstrap::install').returns(task2)
-      task3 = mock('service_task')
-      task3.stubs(:task_hash).returns('name' => 'service')
-      task3.stubs(:runnable_with?).returns(true)
-      Puppet::Pal::ScriptCompiler.any_instance.stubs(:task_signature).with('service').returns(task3)
+      task1 = double('version_task')
+      allow(task1).to receive(:task_hash).and_return('name' => 'openvox_bootstrap::check')
+      allow(task1).to receive(:runnable_with?).and_return(true)
+      allow_any_instance_of(Puppet::Pal::ScriptCompiler).to receive(:task_signature).with('openvox_bootstrap::check').and_return(task1)
+      task2 = double('install_task')
+      allow(task2).to receive(:task_hash).and_return('name' => 'openvox_bootstrap::install')
+      allow(task2).to receive(:runnable_with?).and_return(true)
+      allow_any_instance_of(Puppet::Pal::ScriptCompiler).to receive(:task_signature).with('openvox_bootstrap::install').and_return(task2)
+      task3 = double('service_task')
+      allow(task3).to receive(:task_hash).and_return('name' => 'service')
+      allow(task3).to receive(:runnable_with?).and_return(true)
+      allow_any_instance_of(Puppet::Pal::ScriptCompiler).to receive(:task_signature).with('service').and_return(task3)
     end
 
     it 'sets puppet-agent feature and gathers facts' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
-      executor.expects(:run_task)
-              .with(anything, custom_facts_task, includes('plugins'), {})
-              .returns(facts)
+      expect(executor).to receive(:run_task)
+              .with(anything, custom_facts_task, hash_including('plugins'), {})
+              .and_return(facts)
 
-      plugins.expects(:get_hook)
+      expect(plugins).to receive(:get_hook)
              .twice
              .with("openvox_bootstrap", :puppet_library)
-             .returns(task_hook)
+             .and_return(task_hook)
 
       is_expected.to run.with_params(hostnames.join(','))
       targets.each do |target|
-        expect(inventory.features(target)).to include('puppet-agent') unless target.transport == 'pcp'
+        expect(inventory.features(target)).to include('puppet-agent') unless target.transport == 'remote'
         expect(inventory.facts(target)).to eq(fact)
       end
     end
 
     it 'escalates if provided _run_as' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
-      executor.expects(:run_task)
-              .with(anything, custom_facts_task, includes('plugins'), '_run_as' => 'root')
-              .returns(facts)
+      expect(executor).to receive(:run_task)
+              .with(anything, custom_facts_task, hash_including('plugins'), { '_run_as' => 'root' })
+              .and_return(facts)
 
-      plugins.expects(:get_hook)
+      expect(plugins).to receive(:get_hook)
              .twice
              .with("openvox_bootstrap", :puppet_library)
-             .returns(task_hook)
+             .and_return(task_hook)
 
       is_expected.to run.with_params(hostnames, '_run_as' => 'root')
       targets.each do |target|
-        expect(inventory.features(target)).to include('puppet-agent') unless target.transport == 'pcp'
+        expect(inventory.features(target)).to include('puppet-agent') unless target.transport == 'remote'
         expect(inventory.facts(target)).to eq(fact)
       end
     end
 
     it 'ignores unsupported metaparameters' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
-      executor.expects(:run_task)
-              .with(anything, custom_facts_task, includes('plugins'), {})
-              .returns(facts)
+      expect(executor).to receive(:run_task)
+              .with(anything, custom_facts_task, hash_including('plugins'), {})
+              .and_return(facts)
 
-      plugins.expects(:get_hook)
+      expect(plugins).to receive(:get_hook)
              .twice
              .with("openvox_bootstrap", :puppet_library)
-             .returns(task_hook)
+             .and_return(task_hook)
 
       is_expected.to run.with_params(hostnames, '_noop' => true)
       targets.each do |target|
-        expect(inventory.features(target)).to include('puppet-agent') unless target.transport == 'pcp'
+        expect(inventory.features(target)).to include('puppet-agent') unless target.transport == 'remote'
         expect(inventory.facts(target)).to eq(fact)
       end
     end
@@ -119,14 +121,14 @@ describe 'apply_prep' do
       results = Bolt::ResultSet.new(
         targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not gather facts' }) }
       )
-      executor.expects(:run_task)
-              .with(anything, custom_facts_task, includes('plugins'), {})
-              .returns(results)
+      expect(executor).to receive(:run_task)
+              .with(anything, custom_facts_task, hash_including('plugins'), {})
+              .and_return(results)
 
-      plugins.expects(:get_hook)
+      expect(plugins).to receive(:get_hook)
              .twice
              .with("openvox_bootstrap", :puppet_library)
-             .returns(task_hook)
+             .and_return(task_hook)
 
       is_expected.to run.with_params(hostnames).and_raise_error(
         Bolt::RunFailure, "run_task 'custom_facts_task' failed on #{targets.count} targets"
@@ -153,13 +155,13 @@ describe 'apply_prep' do
 
       it 'installs the agent if not present' do
         facts = Bolt::ResultSet.new([Bolt::Result.new(target, value: fact)])
-        executor.expects(:run_task)
-                .with([target], custom_facts_task, includes('plugins'), {})
-                .returns(facts)
+        expect(executor).to receive(:run_task)
+                .with([target], custom_facts_task, hash_including('plugins'), {})
+                .and_return(facts)
 
-        plugins.expects(:get_hook)
+        expect(plugins).to receive(:get_hook)
                .with("task", :puppet_library)
-               .returns(task_hook)
+               .and_return(task_hook)
 
         is_expected.to run.with_params(hostname)
         expect(inventory.features(target)).to include('puppet-agent')
@@ -184,13 +186,13 @@ describe 'apply_prep' do
 
       it 'installs the agent if not present' do
         facts = Bolt::ResultSet.new([Bolt::Result.new(target, value: fact)])
-        executor.expects(:run_task)
-                .with([target], custom_facts_task, includes('plugins'), {})
-                .returns(facts)
+        expect(executor).to receive(:run_task)
+                .with([target], custom_facts_task, hash_including('plugins'), {})
+                .and_return(facts)
 
-        plugins.expects(:get_hook)
+        expect(plugins).to receive(:get_hook)
                .with('openvox_bootstrap', :puppet_library)
-               .returns(task_hook)
+               .and_return(task_hook)
 
         is_expected.to run.with_params(hostname)
         expect(inventory.features(target)).to include('puppet-agent')
@@ -199,26 +201,26 @@ describe 'apply_prep' do
     end
   end
 
-  context 'with only pcp targets' do
-    let(:hostnames)         { %w[pcp://foo pcp://bar] }
+  context 'with only remote targets' do
+    let(:hostnames)         { %w[remote://foo remote://bar] }
     let(:targets)           { hostnames.map { |h| inventory.get_target(h) } }
     let(:fact)              { { 'osfamily' => 'none' } }
     let(:custom_facts_task) { Bolt::Task.new('custom_facts_task') }
 
     before(:each) do
-      applicator.stubs(:build_plugin_tarball).returns(:tarball)
-      applicator.stubs(:custom_facts_task).returns(custom_facts_task)
+      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
+      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
     end
 
     it 'sets feature and gathers facts' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
-      executor.expects(:run_task)
-              .with(targets, custom_facts_task, includes('plugins'), {})
-              .returns(facts)
+      expect(executor).to receive(:run_task)
+              .with(targets, custom_facts_task, hash_including('plugins'), {})
+              .and_return(facts)
 
       is_expected.to run.with_params(hostnames.join(','))
       targets.each do |target|
-        expect(inventory.features(target)).to include('puppet-agent') unless target.transport == 'pcp'
+        expect(inventory.features(target)).to include('puppet-agent') unless target.transport == 'remote'
         expect(inventory.facts(target)).to eq(fact)
       end
     end
@@ -231,16 +233,16 @@ describe 'apply_prep' do
     let(:custom_facts_task) { Bolt::Task.new('custom_facts_task') }
 
     before(:each) do
-      applicator.stubs(:build_plugin_tarball).returns(:tarball)
-      applicator.stubs(:custom_facts_task).returns(custom_facts_task)
+      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
+      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
       targets.each { |target| inventory.set_feature(target, 'puppet-agent') }
     end
 
     it 'sets feature and gathers facts' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
-      executor.expects(:run_task)
-              .with(targets, custom_facts_task, includes('plugins'), {})
-              .returns(facts)
+      expect(executor).to receive(:run_task)
+              .with(targets, custom_facts_task, hash_including('plugins'), {})
+              .and_return(facts)
 
       is_expected.to run.with_params(hostnames.join(','))
       targets.each do |target|
@@ -257,19 +259,19 @@ describe 'apply_prep' do
     let(:custom_facts_task) { Bolt::Task.new('custom_facts_task') }
 
     before(:each) do
-      applicator.stubs(:build_plugin_tarball).returns(:tarball)
-      applicator.stubs(:custom_facts_task).returns(custom_facts_task)
+      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
+      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
       targets.each { |target| inventory.set_feature(target, 'puppet-agent') }
     end
 
     it 'only uses required plugins' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
-      executor.expects(:run_task)
-              .with(anything, custom_facts_task, includes('plugins'), {})
-              .returns(facts)
+      expect(executor).to receive(:run_task)
+              .with(anything, custom_facts_task, hash_including('plugins'), {})
+              .and_return(facts)
 
-      Puppet.expects(:debug).at_least(1)
-      Puppet.expects(:debug).with("Syncing only required modules: non-existing-module.")
+      allow(Puppet).to receive(:debug)
+      expect(Puppet).to receive(:debug).with("Syncing only required modules: non-existing-module.")
       is_expected.to run.with_params(hostnames,
                                      '_required_modules' => ['non-existing-module'])
     end
@@ -283,12 +285,12 @@ describe 'apply_prep' do
     let(:resultset)         { Bolt::ResultSet.new([result]) }
 
     before(:each) do
-      applicator.stubs(:build_plugin_tarball).returns(:tarball)
-      applicator.stubs(:custom_facts_task).returns(custom_facts_task)
+      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
+      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
 
-      plugins.expects(:get_hook)
+      expect(plugins).to receive(:get_hook)
              .with("openvox_bootstrap", :puppet_library)
-             .returns(task_hook)
+             .and_return(task_hook)
     end
 
     context 'with failing hook' do
@@ -304,9 +306,9 @@ describe 'apply_prep' do
       let(:task_result)   { { '_error' => { 'msg' => 'failure' } } }
 
       it 'continues executing' do
-        executor.expects(:run_task)
-                .with(targets, custom_facts_task, includes('plugins'), '_catch_errors' => true)
-                .returns(resultset)
+        expect(executor).to receive(:run_task)
+                .with(targets, custom_facts_task, hash_including('plugins'), { '_catch_errors' => true })
+                .and_return(resultset)
 
         is_expected.to run.with_params(host, '_catch_errors' => true)
       end

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -11,8 +11,6 @@ require 'bolt/target'
 require 'bolt/task'
 
 describe 'apply_prep' do
-  include SpecFixtures
-
   let(:applicator)    { double('Bolt::Applicator') }
   let(:config)        { Bolt::Config.default }
   let(:executor)      { Bolt::Executor.new }
@@ -44,35 +42,31 @@ describe 'apply_prep' do
     let(:service_task)      { Bolt::Task.new('service') }
 
     before(:each) do
-      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
-      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
+      allow(applicator).to receive_messages(build_plugin_tarball: :tarball, custom_facts_task: custom_facts_task)
       inventory.get_targets(targets)
       targets.each { |t| inventory.set_feature(t, 'puppet-agent', false) }
 
       task1 = double('version_task')
-      allow(task1).to receive(:task_hash).and_return('name' => 'openvox_bootstrap::check')
-      allow(task1).to receive(:runnable_with?).and_return(true)
+      allow(task1).to receive_messages(task_hash: { 'name' => 'openvox_bootstrap::check' }, runnable_with?: true)
       allow_any_instance_of(Puppet::Pal::ScriptCompiler).to receive(:task_signature).with('openvox_bootstrap::check').and_return(task1)
       task2 = double('install_task')
-      allow(task2).to receive(:task_hash).and_return('name' => 'openvox_bootstrap::install')
-      allow(task2).to receive(:runnable_with?).and_return(true)
+      allow(task2).to receive_messages(task_hash: { 'name' => 'openvox_bootstrap::install' }, runnable_with?: true)
       allow_any_instance_of(Puppet::Pal::ScriptCompiler).to receive(:task_signature).with('openvox_bootstrap::install').and_return(task2)
       task3 = double('service_task')
-      allow(task3).to receive(:task_hash).and_return('name' => 'service')
-      allow(task3).to receive(:runnable_with?).and_return(true)
+      allow(task3).to receive_messages(task_hash: { 'name' => 'service' }, runnable_with?: true)
       allow_any_instance_of(Puppet::Pal::ScriptCompiler).to receive(:task_signature).with('service').and_return(task3)
     end
 
     it 'sets puppet-agent feature and gathers facts' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
       expect(executor).to receive(:run_task)
-              .with(anything, custom_facts_task, hash_including('plugins'), {})
-              .and_return(facts)
+        .with(anything, custom_facts_task, hash_including('plugins'), {})
+        .and_return(facts)
 
       expect(plugins).to receive(:get_hook)
-             .twice
-             .with("openvox_bootstrap", :puppet_library)
-             .and_return(task_hook)
+        .twice
+        .with("openvox_bootstrap", :puppet_library)
+        .and_return(task_hook)
 
       is_expected.to run.with_params(hostnames.join(','))
       targets.each do |target|
@@ -84,13 +78,13 @@ describe 'apply_prep' do
     it 'escalates if provided _run_as' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
       expect(executor).to receive(:run_task)
-              .with(anything, custom_facts_task, hash_including('plugins'), { '_run_as' => 'root' })
-              .and_return(facts)
+        .with(anything, custom_facts_task, hash_including('plugins'), { '_run_as' => 'root' })
+        .and_return(facts)
 
       expect(plugins).to receive(:get_hook)
-             .twice
-             .with("openvox_bootstrap", :puppet_library)
-             .and_return(task_hook)
+        .twice
+        .with("openvox_bootstrap", :puppet_library)
+        .and_return(task_hook)
 
       is_expected.to run.with_params(hostnames, '_run_as' => 'root')
       targets.each do |target|
@@ -102,13 +96,13 @@ describe 'apply_prep' do
     it 'ignores unsupported metaparameters' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
       expect(executor).to receive(:run_task)
-              .with(anything, custom_facts_task, hash_including('plugins'), {})
-              .and_return(facts)
+        .with(anything, custom_facts_task, hash_including('plugins'), {})
+        .and_return(facts)
 
       expect(plugins).to receive(:get_hook)
-             .twice
-             .with("openvox_bootstrap", :puppet_library)
-             .and_return(task_hook)
+        .twice
+        .with("openvox_bootstrap", :puppet_library)
+        .and_return(task_hook)
 
       is_expected.to run.with_params(hostnames, '_noop' => true)
       targets.each do |target|
@@ -122,13 +116,13 @@ describe 'apply_prep' do
         targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not gather facts' }) }
       )
       expect(executor).to receive(:run_task)
-              .with(anything, custom_facts_task, hash_including('plugins'), {})
-              .and_return(results)
+        .with(anything, custom_facts_task, hash_including('plugins'), {})
+        .and_return(results)
 
       expect(plugins).to receive(:get_hook)
-             .twice
-             .with("openvox_bootstrap", :puppet_library)
-             .and_return(task_hook)
+        .twice
+        .with("openvox_bootstrap", :puppet_library)
+        .and_return(task_hook)
 
       is_expected.to run.with_params(hostnames).and_raise_error(
         Bolt::RunFailure, "run_task 'custom_facts_task' failed on #{targets.count} targets"
@@ -156,12 +150,12 @@ describe 'apply_prep' do
       it 'installs the agent if not present' do
         facts = Bolt::ResultSet.new([Bolt::Result.new(target, value: fact)])
         expect(executor).to receive(:run_task)
-                .with([target], custom_facts_task, hash_including('plugins'), {})
-                .and_return(facts)
+          .with([target], custom_facts_task, hash_including('plugins'), {})
+          .and_return(facts)
 
         expect(plugins).to receive(:get_hook)
-               .with("task", :puppet_library)
-               .and_return(task_hook)
+          .with("task", :puppet_library)
+          .and_return(task_hook)
 
         is_expected.to run.with_params(hostname)
         expect(inventory.features(target)).to include('puppet-agent')
@@ -187,12 +181,12 @@ describe 'apply_prep' do
       it 'installs the agent if not present' do
         facts = Bolt::ResultSet.new([Bolt::Result.new(target, value: fact)])
         expect(executor).to receive(:run_task)
-                .with([target], custom_facts_task, hash_including('plugins'), {})
-                .and_return(facts)
+          .with([target], custom_facts_task, hash_including('plugins'), {})
+          .and_return(facts)
 
         expect(plugins).to receive(:get_hook)
-               .with('openvox_bootstrap', :puppet_library)
-               .and_return(task_hook)
+          .with('openvox_bootstrap', :puppet_library)
+          .and_return(task_hook)
 
         is_expected.to run.with_params(hostname)
         expect(inventory.features(target)).to include('puppet-agent')
@@ -208,15 +202,14 @@ describe 'apply_prep' do
     let(:custom_facts_task) { Bolt::Task.new('custom_facts_task') }
 
     before(:each) do
-      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
-      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
+      allow(applicator).to receive_messages(build_plugin_tarball: :tarball, custom_facts_task: custom_facts_task)
     end
 
     it 'sets feature and gathers facts' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
       expect(executor).to receive(:run_task)
-              .with(targets, custom_facts_task, hash_including('plugins'), {})
-              .and_return(facts)
+        .with(targets, custom_facts_task, hash_including('plugins'), {})
+        .and_return(facts)
 
       is_expected.to run.with_params(hostnames.join(','))
       targets.each do |target|
@@ -233,16 +226,15 @@ describe 'apply_prep' do
     let(:custom_facts_task) { Bolt::Task.new('custom_facts_task') }
 
     before(:each) do
-      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
-      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
+      allow(applicator).to receive_messages(build_plugin_tarball: :tarball, custom_facts_task: custom_facts_task)
       targets.each { |target| inventory.set_feature(target, 'puppet-agent') }
     end
 
     it 'sets feature and gathers facts' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
       expect(executor).to receive(:run_task)
-              .with(targets, custom_facts_task, hash_including('plugins'), {})
-              .and_return(facts)
+        .with(targets, custom_facts_task, hash_including('plugins'), {})
+        .and_return(facts)
 
       is_expected.to run.with_params(hostnames.join(','))
       targets.each do |target|
@@ -259,16 +251,15 @@ describe 'apply_prep' do
     let(:custom_facts_task) { Bolt::Task.new('custom_facts_task') }
 
     before(:each) do
-      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
-      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
+      allow(applicator).to receive_messages(build_plugin_tarball: :tarball, custom_facts_task: custom_facts_task)
       targets.each { |target| inventory.set_feature(target, 'puppet-agent') }
     end
 
     it 'only uses required plugins' do
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
       expect(executor).to receive(:run_task)
-              .with(anything, custom_facts_task, hash_including('plugins'), {})
-              .and_return(facts)
+        .with(anything, custom_facts_task, hash_including('plugins'), {})
+        .and_return(facts)
 
       allow(Puppet).to receive(:debug)
       expect(Puppet).to receive(:debug).with("Syncing only required modules: non-existing-module.")
@@ -285,12 +276,11 @@ describe 'apply_prep' do
     let(:resultset)         { Bolt::ResultSet.new([result]) }
 
     before(:each) do
-      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
-      allow(applicator).to receive(:custom_facts_task).and_return(custom_facts_task)
+      allow(applicator).to receive_messages(build_plugin_tarball: :tarball, custom_facts_task: custom_facts_task)
 
       expect(plugins).to receive(:get_hook)
-             .with("openvox_bootstrap", :puppet_library)
-             .and_return(task_hook)
+        .with("openvox_bootstrap", :puppet_library)
+        .and_return(task_hook)
     end
 
     context 'with failing hook' do
@@ -307,8 +297,8 @@ describe 'apply_prep' do
 
       it 'continues executing' do
         expect(executor).to receive(:run_task)
-                .with(targets, custom_facts_task, hash_including('plugins'), { '_catch_errors' => true })
-                .and_return(resultset)
+          .with(targets, custom_facts_task, hash_including('plugins'), { '_catch_errors' => true })
+          .and_return(resultset)
 
         is_expected.to run.with_params(host, '_catch_errors' => true)
       end

--- a/bolt-modules/boltlib/spec/functions/background_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/background_spec.rb
@@ -6,23 +6,25 @@ require 'bolt/executor'
 require 'bolt/plan_future'
 
 describe 'background' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:name)      { "Pluralize" }
   let(:object)    { "noodle" }
   let(:future)    { Bolt::PlanFuture.new('foo', name, plan_id: 1234) }
   let(:executor)  { Bolt::Executor.new }
 
-  around(:each) do |example|
-    executor.expects(:get_current_plan_id).returns(1234)
+  before(:each) do
+    expect(executor).to receive(:get_current_plan_id).and_return(1234)
     Puppet[:tasks] = true
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'reports the function call to analytics' do
-    executor.expects(:report_function_call).with('background')
+    expect(executor).to receive(:report_function_call).with('background')
 
     is_expected.to(run
       .with_params(name)
@@ -30,9 +32,9 @@ describe 'background' do
   end
 
   it 'returns the PlanFuture the executor creates' do
-    executor.expects(:create_future)
-            .with(has_entries(scope: anything, name: name))
-            .returns(future)
+    expect(executor).to receive(:create_future)
+            .with(hash_including(scope: anything, name: name))
+            .and_return(future)
 
     is_expected.to(run
       .with_params(name)

--- a/bolt-modules/boltlib/spec/functions/background_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/background_spec.rb
@@ -6,8 +6,6 @@ require 'bolt/executor'
 require 'bolt/plan_future'
 
 describe 'background' do
-  include SpecFixtures
-
   let(:name)      { "Pluralize" }
   let(:object)    { "noodle" }
   let(:future)    { Bolt::PlanFuture.new('foo', name, plan_id: 1234) }
@@ -33,8 +31,8 @@ describe 'background' do
 
   it 'returns the PlanFuture the executor creates' do
     expect(executor).to receive(:create_future)
-            .with(hash_including(scope: anything, name: name))
-            .and_return(future)
+      .with(hash_including(scope: anything, name: name))
+      .and_return(future)
 
     is_expected.to(run
       .with_params(name)

--- a/bolt-modules/boltlib/spec/functions/catch_errors_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/catch_errors_spec.rb
@@ -7,15 +7,17 @@ describe 'catch_errors' do
   let(:executor) { Bolt::Executor.new }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('catch_errors')
+    expect(executor).to receive(:report_function_call).with('catch_errors')
     is_expected.to(run
       .with_lambda { 'abcd' })
   end

--- a/bolt-modules/boltlib/spec/functions/download_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/download_file_spec.rb
@@ -8,8 +8,6 @@ require 'bolt/target'
 require 'bolt/project'
 
 describe 'download_file' do
-  include SpecFixtures
-
   let(:executor)      { Bolt::Executor.new }
   let(:inventory)     { double('inventory') }
   let(:project)       { Bolt::Project.default_project }
@@ -17,8 +15,7 @@ describe 'download_file' do
 
   before(:each) do
     Puppet[:tasks] = tasks_enabled
-    allow(inventory).to receive(:version).and_return(2)
-    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    allow(inventory).to receive_messages(version: 2, target_implementation_class: Bolt::Target)
     Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory, bolt_project: project)
   end
 
@@ -44,12 +41,12 @@ describe 'download_file' do
 
     it 'with path of source and destination' do
       expect(executor).to receive(:download_file)
-              .with([target], source, project_destination, {}, [])
-              .and_return(result_set)
+        .with([target], source, project_destination, {}, [])
+        .and_return(result_set)
 
       allow(inventory).to receive(:get_targets)
-               .with(hostname)
-               .and_return([target])
+        .with(hostname)
+        .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -62,8 +59,8 @@ describe 'download_file' do
       expect(executor).not_to receive(:download_file)
 
       allow(inventory).to receive(:get_targets)
-               .with(hostname)
-               .and_return([target])
+        .with(hostname)
+        .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -76,8 +73,8 @@ describe 'download_file' do
       expect(executor).not_to receive(:download_file)
 
       allow(inventory).to receive(:get_targets)
-               .with(hostname)
-               .and_return([target])
+        .with(hostname)
+        .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -90,8 +87,8 @@ describe 'download_file' do
       expect(executor).not_to receive(:download_file)
 
       allow(inventory).to receive(:get_targets)
-               .with(hostname)
-               .and_return([target])
+        .with(hostname)
+        .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -103,12 +100,12 @@ describe 'download_file' do
       project_destination = project.downloads + destination.strip
 
       expect(executor).to receive(:download_file)
-              .with([target], source, project_destination, {}, [])
-              .and_return(result_set)
+        .with([target], source, project_destination, {}, [])
+        .and_return(result_set)
 
       allow(inventory).to receive(:get_targets)
-               .with(hostname)
-               .and_return([target])
+        .with(hostname)
+        .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -120,12 +117,12 @@ describe 'download_file' do
       project_destination = project.downloads + destination
 
       expect(executor).to receive(:download_file)
-              .with([target], source, project_destination, {}, [])
-              .and_return(result_set)
+        .with([target], source, project_destination, {}, [])
+        .and_return(result_set)
 
       allow(inventory).to receive(:get_targets)
-               .with(hostname)
-               .and_return([target])
+        .with(hostname)
+        .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -134,21 +131,21 @@ describe 'download_file' do
 
     it 'deletes contents of existing destination directory' do
       allow(Dir).to receive(:exist?)
-         .with(project_destination)
-         .and_return(true)
+        .with(project_destination)
+        .and_return(true)
 
       allow(FileUtils).to receive(:rm_r)
 
       expect(executor).to receive(:download_file)
-              .with([target], source, project_destination, {}, [])
-              .and_return(result_set)
+        .with([target], source, project_destination, {}, [])
+        .and_return(result_set)
 
       allow(inventory).to receive(:get_targets)
-               .with(hostname)
-               .and_return([target])
+        .with(hostname)
+        .and_return([target])
 
       expect(FileUtils).to receive(:rm_r)
-               .with([], secure: true)
+        .with([], secure: true)
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -157,12 +154,12 @@ describe 'download_file' do
 
     it 'with target specified as a Target' do
       expect(executor).to receive(:download_file)
-              .with([target], source, project_destination, {}, [])
-              .and_return(result_set)
+        .with([target], source, project_destination, {}, [])
+        .and_return(result_set)
 
       allow(inventory).to receive(:get_targets)
-               .with(target)
-               .and_return([target])
+        .with(target)
+        .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, target)
@@ -171,12 +168,12 @@ describe 'download_file' do
 
     it 'runs as another user' do
       expect(executor).to receive(:download_file)
-              .with([target], source, project_destination, { run_as: 'soandso' }, [])
-              .and_return(result_set)
+        .with([target], source, project_destination, { run_as: 'soandso' }, [])
+        .and_return(result_set)
 
       allow(inventory).to receive(:get_targets)
-               .with(target)
-               .and_return([target])
+        .with(target)
+        .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, target, '_run_as' => 'soandso')
@@ -185,15 +182,15 @@ describe 'download_file' do
 
     it 'reports the call to analytics' do
       expect(executor).to receive(:download_file)
-              .with([target], source, project_destination, {}, [])
-              .and_return(result_set)
+        .with([target], source, project_destination, {}, [])
+        .and_return(result_set)
 
       allow(inventory).to receive(:get_targets)
-               .with(hostname)
-               .and_return([target])
+        .with(hostname)
+        .and_return([target])
 
       expect(executor).to receive(:report_function_call)
-              .with('download_file')
+        .with('download_file')
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -205,12 +202,12 @@ describe 'download_file' do
 
       it 'passes the description through if parameters are passed' do
         expect(executor).to receive(:download_file)
-                .with([target], source, project_destination, { description: message }, [])
-                .and_return(result_set)
+          .with([target], source, project_destination, { description: message }, [])
+          .and_return(result_set)
 
         allow(inventory).to receive(:get_targets)
-                 .with(target)
-                 .and_return([target])
+          .with(target)
+          .and_return([target])
 
         is_expected.to run
           .with_params(source, destination, target, message, {})
@@ -219,12 +216,12 @@ describe 'download_file' do
 
       it 'passes the description through if no parameters are passed' do
         expect(executor).to receive(:download_file)
-                .with([target], source, project_destination, { description: message }, [])
-                .and_return(result_set)
+          .with([target], source, project_destination, { description: message }, [])
+          .and_return(result_set)
 
         allow(inventory).to receive(:get_targets)
-                 .with(target)
-                 .and_return([target])
+          .with(target)
+          .and_return([target])
 
         is_expected.to run
           .with_params(source, destination, target, message)
@@ -235,12 +232,12 @@ describe 'download_file' do
     context 'without description' do
       it 'ignores description if parameters are passed' do
         expect(executor).to receive(:download_file)
-                .with([target], source, project_destination, {}, [])
-                .and_return(result_set)
+          .with([target], source, project_destination, {}, [])
+          .and_return(result_set)
 
         allow(inventory).to receive(:get_targets)
-                 .with(target)
-                 .and_return([target])
+          .with(target)
+          .and_return([target])
 
         is_expected.to run
           .with_params(source, destination, target, {})
@@ -249,12 +246,12 @@ describe 'download_file' do
 
       it 'ignores description if no parameters are passed' do
         expect(executor).to receive(:download_file)
-                .with([target], source, project_destination, {}, [])
-                .and_return(result_set)
+          .with([target], source, project_destination, {}, [])
+          .and_return(result_set)
 
         allow(inventory).to receive(:get_targets)
-                 .with(target)
-                 .and_return([target])
+          .with(target)
+          .and_return([target])
 
         is_expected.to run
           .with_params(source, destination, target)
@@ -271,12 +268,12 @@ describe 'download_file' do
 
       it 'propagates multiple hosts and returns multiple results' do
         expect(executor).to receive(:download_file)
-                .with([target, target2], source, project_destination, {}, [])
-                .and_return(result_set)
+          .with([target, target2], source, project_destination, {}, [])
+          .and_return(result_set)
 
         allow(inventory).to receive(:get_targets)
-                 .with([hostname, hostname2])
-                 .and_return([target, target2])
+          .with([hostname, hostname2])
+          .and_return([target, target2])
 
         is_expected.to run
           .with_params(source, destination, [hostname, hostname2])
@@ -288,12 +285,12 @@ describe 'download_file' do
 
         it 'errors by default' do
           expect(executor).to receive(:download_file)
-                  .with([target, target2], source, project_destination, {}, [])
-                  .and_return(result_set)
+            .with([target, target2], source, project_destination, {}, [])
+            .and_return(result_set)
 
           expect(inventory).to receive(:get_targets)
-                   .with([hostname, hostname2])
-                   .and_return([target, target2])
+            .with([hostname, hostname2])
+            .and_return([target, target2])
 
           is_expected.to run
             .with_params(source, destination, [hostname, hostname2])
@@ -302,12 +299,12 @@ describe 'download_file' do
 
         it 'does not error with _catch_errors' do
           expect(executor).to receive(:download_file)
-                  .with([target, target2], source, project_destination, { catch_errors: true }, [])
-                  .and_return(result_set)
+            .with([target, target2], source, project_destination, { catch_errors: true }, [])
+            .and_return(result_set)
 
           expect(inventory).to receive(:get_targets)
-                   .with([hostname, hostname2])
-                   .and_return([target, target2])
+            .with([hostname, hostname2])
+            .and_return([target, target2])
 
           is_expected.to run
             .with_params(source, destination, [hostname, hostname2],

--- a/bolt-modules/boltlib/spec/functions/download_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/download_file_spec.rb
@@ -8,20 +8,22 @@ require 'bolt/target'
 require 'bolt/project'
 
 describe 'download_file' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor)      { Bolt::Executor.new }
-  let(:inventory)     { mock('inventory') }
+  let(:inventory)     { double('inventory') }
   let(:project)       { Bolt::Project.default_project }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory, bolt_project: project) do
-      inventory.stubs(:version).returns(2)
-      inventory.stubs(:target_implementation_class).returns(Bolt::Target)
-      example.run
-    end
+    allow(inventory).to receive(:version).and_return(2)
+    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory, bolt_project: project)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'it calls bolt executor download_file' do
@@ -36,18 +38,18 @@ describe 'download_file' do
     let(:project_destination) { project.downloads + destination }
 
     before(:each) do
-      Puppet.features.stubs(:bolt?).returns(true)
-      Dir.stubs(:exist?).returns(false)
+      allow(Puppet.features).to receive(:bolt?).and_return(true)
+      allow(Dir).to receive(:exist?).and_return(false)
     end
 
     it 'with path of source and destination' do
-      executor.expects(:download_file)
+      expect(executor).to receive(:download_file)
               .with([target], source, project_destination, {}, [])
-              .returns(result_set)
+              .and_return(result_set)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(hostname)
-               .returns([target])
+               .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -57,11 +59,11 @@ describe 'download_file' do
     it 'raises an error when destination is an empty string' do
       destination = ' '
 
-      executor.expects(:download_file).never
+      expect(executor).not_to receive(:download_file)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(hostname)
-               .returns([target])
+               .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -71,11 +73,11 @@ describe 'download_file' do
     it 'raises an error when destination is an aboslute path' do
       destination = '/downloads'
 
-      executor.expects(:download_file).never
+      expect(executor).not_to receive(:download_file)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(hostname)
-               .returns([target])
+               .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -85,11 +87,11 @@ describe 'download_file' do
     it 'raises an error when destination includes path traversal' do
       destination = 'foo/../bar'
 
-      executor.expects(:download_file).never
+      expect(executor).not_to receive(:download_file)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(hostname)
-               .returns([target])
+               .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -100,13 +102,13 @@ describe 'download_file' do
       destination = " foo\n"
       project_destination = project.downloads + destination.strip
 
-      executor.expects(:download_file)
+      expect(executor).to receive(:download_file)
               .with([target], source, project_destination, {}, [])
-              .returns(result_set)
+              .and_return(result_set)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(hostname)
-               .returns([target])
+               .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -117,13 +119,13 @@ describe 'download_file' do
       destination = '~/foo'
       project_destination = project.downloads + destination
 
-      executor.expects(:download_file)
+      expect(executor).to receive(:download_file)
               .with([target], source, project_destination, {}, [])
-              .returns(result_set)
+              .and_return(result_set)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(hostname)
-               .returns([target])
+               .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, hostname)
@@ -131,21 +133,21 @@ describe 'download_file' do
     end
 
     it 'deletes contents of existing destination directory' do
-      Dir.stubs(:exist?)
+      allow(Dir).to receive(:exist?)
          .with(project_destination)
-         .returns(true)
+         .and_return(true)
 
-      FileUtils.stubs(:rm_r)
+      allow(FileUtils).to receive(:rm_r)
 
-      executor.expects(:download_file)
+      expect(executor).to receive(:download_file)
               .with([target], source, project_destination, {}, [])
-              .returns(result_set)
+              .and_return(result_set)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(hostname)
-               .returns([target])
+               .and_return([target])
 
-      FileUtils.expects(:rm_r)
+      expect(FileUtils).to receive(:rm_r)
                .with([], secure: true)
 
       is_expected.to run
@@ -154,13 +156,13 @@ describe 'download_file' do
     end
 
     it 'with target specified as a Target' do
-      executor.expects(:download_file)
+      expect(executor).to receive(:download_file)
               .with([target], source, project_destination, {}, [])
-              .returns(result_set)
+              .and_return(result_set)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(target)
-               .returns([target])
+               .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, target)
@@ -168,13 +170,13 @@ describe 'download_file' do
     end
 
     it 'runs as another user' do
-      executor.expects(:download_file)
+      expect(executor).to receive(:download_file)
               .with([target], source, project_destination, { run_as: 'soandso' }, [])
-              .returns(result_set)
+              .and_return(result_set)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(target)
-               .returns([target])
+               .and_return([target])
 
       is_expected.to run
         .with_params(source, destination, target, '_run_as' => 'soandso')
@@ -182,15 +184,15 @@ describe 'download_file' do
     end
 
     it 'reports the call to analytics' do
-      executor.expects(:download_file)
+      expect(executor).to receive(:download_file)
               .with([target], source, project_destination, {}, [])
-              .returns(result_set)
+              .and_return(result_set)
 
-      inventory.stubs(:get_targets)
+      allow(inventory).to receive(:get_targets)
                .with(hostname)
-               .returns([target])
+               .and_return([target])
 
-      executor.expects(:report_function_call)
+      expect(executor).to receive(:report_function_call)
               .with('download_file')
 
       is_expected.to run
@@ -202,13 +204,13 @@ describe 'download_file' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:download_file)
+        expect(executor).to receive(:download_file)
                 .with([target], source, project_destination, { description: message }, [])
-                .returns(result_set)
+                .and_return(result_set)
 
-        inventory.stubs(:get_targets)
+        allow(inventory).to receive(:get_targets)
                  .with(target)
-                 .returns([target])
+                 .and_return([target])
 
         is_expected.to run
           .with_params(source, destination, target, message, {})
@@ -216,13 +218,13 @@ describe 'download_file' do
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:download_file)
+        expect(executor).to receive(:download_file)
                 .with([target], source, project_destination, { description: message }, [])
-                .returns(result_set)
+                .and_return(result_set)
 
-        inventory.stubs(:get_targets)
+        allow(inventory).to receive(:get_targets)
                  .with(target)
-                 .returns([target])
+                 .and_return([target])
 
         is_expected.to run
           .with_params(source, destination, target, message)
@@ -232,13 +234,13 @@ describe 'download_file' do
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:download_file)
+        expect(executor).to receive(:download_file)
                 .with([target], source, project_destination, {}, [])
-                .returns(result_set)
+                .and_return(result_set)
 
-        inventory.stubs(:get_targets)
+        allow(inventory).to receive(:get_targets)
                  .with(target)
-                 .returns([target])
+                 .and_return([target])
 
         is_expected.to run
           .with_params(source, destination, target, {})
@@ -246,13 +248,13 @@ describe 'download_file' do
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:download_file)
+        expect(executor).to receive(:download_file)
                 .with([target], source, project_destination, {}, [])
-                .returns(result_set)
+                .and_return(result_set)
 
-        inventory.stubs(:get_targets)
+        allow(inventory).to receive(:get_targets)
                  .with(target)
-                 .returns([target])
+                 .and_return([target])
 
         is_expected.to run
           .with_params(source, destination, target)
@@ -268,13 +270,13 @@ describe 'download_file' do
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 
       it 'propagates multiple hosts and returns multiple results' do
-        executor.expects(:download_file)
+        expect(executor).to receive(:download_file)
                 .with([target, target2], source, project_destination, {}, [])
-                .returns(result_set)
+                .and_return(result_set)
 
-        inventory.stubs(:get_targets)
+        allow(inventory).to receive(:get_targets)
                  .with([hostname, hostname2])
-                 .returns([target, target2])
+                 .and_return([target, target2])
 
         is_expected.to run
           .with_params(source, destination, [hostname, hostname2])
@@ -285,13 +287,13 @@ describe 'download_file' do
         let(:result2) { Bolt::Result.new(target2, error: { 'msg' => 'oops' }) }
 
         it 'errors by default' do
-          executor.expects(:download_file)
+          expect(executor).to receive(:download_file)
                   .with([target, target2], source, project_destination, {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
-          inventory.expects(:get_targets)
+          expect(inventory).to receive(:get_targets)
                    .with([hostname, hostname2])
-                   .returns([target, target2])
+                   .and_return([target, target2])
 
           is_expected.to run
             .with_params(source, destination, [hostname, hostname2])
@@ -299,13 +301,13 @@ describe 'download_file' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:download_file)
+          expect(executor).to receive(:download_file)
                   .with([target, target2], source, project_destination, { catch_errors: true }, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
-          inventory.expects(:get_targets)
+          expect(inventory).to receive(:get_targets)
                    .with([hostname, hostname2])
-                   .returns([target, target2])
+                   .and_return([target, target2])
 
           is_expected.to run
             .with_params(source, destination, [hostname, hostname2],
@@ -315,8 +317,8 @@ describe 'download_file' do
     end
 
     it 'without targets - does not invoke bolt' do
-      executor.expects(:download_file).never
-      inventory.expects(:get_targets).with([]).returns([])
+      expect(executor).not_to receive(:download_file)
+      expect(inventory).to receive(:get_targets).with([]).and_return([])
 
       is_expected.to run
         .with_params(source, destination, [])
@@ -325,7 +327,7 @@ describe 'download_file' do
   end
 
   context 'running in parallel' do
-    let(:future) { mock('future') }
+    let(:future) { double('future') }
     let(:hostname) { 'test.example.com' }
     let(:target) { Bolt::Target.new(hostname) }
     let(:result) { Bolt::Result.new(target, value: { 'stdout' => hostname }) }
@@ -334,10 +336,10 @@ describe 'download_file' do
     let(:destination) { 'downloads' }
 
     it 'executes in a thread if the executor is in parallel mode' do
-      inventory.expects(:get_targets).with(hostname).returns([target])
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
-      executor.expects(:in_parallel?).returns(true)
-      executor.expects(:run_in_thread).returns(result_set)
+      expect(executor).to receive(:in_parallel?).and_return(true)
+      expect(executor).to receive(:run_in_thread).and_return(result_set)
 
       is_expected.to run
         .with_params(source, destination, hostname)

--- a/bolt-modules/boltlib/spec/functions/facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/facts_spec.rb
@@ -5,18 +5,20 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'facts' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:hostname) { 'example' }
   let(:target) { inventory.get_target(hostname) }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = true
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'should return an empty hash if no facts are set' do
@@ -24,7 +26,7 @@ describe 'facts' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('facts')
+    expect(executor).to receive(:report_function_call).with('facts')
     is_expected.to run.with_params(target)
   end
 end

--- a/bolt-modules/boltlib/spec/functions/facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/facts_spec.rb
@@ -5,8 +5,6 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'facts' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:hostname) { 'example' }

--- a/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
@@ -5,8 +5,6 @@ require 'bolt/executor'
 require 'bolt/error'
 
 describe 'fail_plan' do
-  include SpecFixtures
-
   let(:tasks_enabled) { true }
   let(:executor) { Bolt::Executor.new }
 

--- a/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
@@ -5,16 +5,18 @@ require 'bolt/executor'
 require 'bolt/error'
 
 describe 'fail_plan' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:tasks_enabled) { true }
   let(:executor) { Bolt::Executor.new }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'raises an error from arguments' do
@@ -28,7 +30,7 @@ describe 'fail_plan' do
 
   it 'reports the call to analytics' do
     executor = Bolt::Executor.new
-    executor.expects(:report_function_call).with('fail_plan')
+    expect(executor).to receive(:report_function_call).with('fail_plan')
 
     Puppet.override(bolt_executor: executor) do
       is_expected.to run.with_params('foo').and_raise_error(Bolt::PlanFailure)

--- a/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
@@ -9,39 +9,41 @@ require 'bolt/target'
 require 'bolt/task'
 
 describe 'get_resources' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
-  let(:applicator) { mock('Bolt::Applicator') }
+  let(:applicator) { double('Bolt::Applicator') }
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    executor.stubs(:noop).returns(false)
+    allow(executor).to receive(:noop).and_return(false)
 
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory, apply_executor: applicator) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory, apply_executor: applicator)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'with targets' do
-    let(:hostnames) { %w[a.b.com winrm://x.y.com pcp://foo] }
+    let(:hostnames) { %w[a.b.com winrm://x.y.com remote://foo] }
     let(:targets) { hostnames.map { |h| inventory.get_target(h) } }
     let(:query_resources_task) { Bolt::Task.new('query_resources_task') }
 
     before(:each) do
-      applicator.stubs(:build_plugin_tarball).returns(:tarball)
-      applicator.stubs(:query_resources_task).returns(query_resources_task)
+      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
+      allow(applicator).to receive(:query_resources_task).and_return(query_resources_task)
     end
 
     it 'queries a single resource' do
       results = Bolt::ResultSet.new(
         targets.map { |t| Bolt::Result.new(t, value: { 'some' => 'resources' }) }
       )
-      executor.expects(:run_task).with(targets,
+      expect(executor).to receive(:run_task).with(targets,
                                        query_resources_task,
-                                       has_entry('resources', ['file'])).returns(results)
+                                       hash_including('resources' => ['file'])).and_return(results)
 
       is_expected.to run.with_params(hostnames, 'file').and_return(results)
     end
@@ -51,9 +53,9 @@ describe 'get_resources' do
         targets.map { |t| Bolt::Result.new(t, value: { 'some' => 'resources' }) }
       )
       resources = ['User', 'File[/tmp]']
-      executor.expects(:run_task).with(targets,
+      expect(executor).to receive(:run_task).with(targets,
                                        query_resources_task,
-                                       has_entry('resources', resources)).returns(results)
+                                       hash_including('resources' => resources)).and_return(results)
 
       is_expected.to run.with_params(hostnames, resources).and_return(results)
     end
@@ -62,7 +64,7 @@ describe 'get_resources' do
       results = Bolt::ResultSet.new(
         targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not query resources' }) }
       )
-      executor.expects(:run_task).with(targets, query_resources_task, includes('plugins')).returns(results)
+      expect(executor).to receive(:run_task).with(targets, query_resources_task, hash_including('plugins')).and_return(results)
 
       is_expected.to run.with_params(hostnames, []).and_raise_error(
         Bolt::RunFailure, "run_task 'query_resources_task' failed on #{targets.count} targets"

--- a/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
@@ -9,8 +9,6 @@ require 'bolt/target'
 require 'bolt/task'
 
 describe 'get_resources' do
-  include SpecFixtures
-
   let(:applicator) { double('Bolt::Applicator') }
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
@@ -33,8 +31,7 @@ describe 'get_resources' do
     let(:query_resources_task) { Bolt::Task.new('query_resources_task') }
 
     before(:each) do
-      allow(applicator).to receive(:build_plugin_tarball).and_return(:tarball)
-      allow(applicator).to receive(:query_resources_task).and_return(query_resources_task)
+      allow(applicator).to receive_messages(build_plugin_tarball: :tarball, query_resources_task: query_resources_task)
     end
 
     it 'queries a single resource' do
@@ -42,8 +39,8 @@ describe 'get_resources' do
         targets.map { |t| Bolt::Result.new(t, value: { 'some' => 'resources' }) }
       )
       expect(executor).to receive(:run_task).with(targets,
-                                       query_resources_task,
-                                       hash_including('resources' => ['file'])).and_return(results)
+                                                  query_resources_task,
+                                                  hash_including('resources' => ['file'])).and_return(results)
 
       is_expected.to run.with_params(hostnames, 'file').and_return(results)
     end
@@ -54,8 +51,8 @@ describe 'get_resources' do
       )
       resources = ['User', 'File[/tmp]']
       expect(executor).to receive(:run_task).with(targets,
-                                       query_resources_task,
-                                       hash_including('resources' => resources)).and_return(results)
+                                                  query_resources_task,
+                                                  hash_including('resources' => resources)).and_return(results)
 
       is_expected.to run.with_params(hostnames, resources).and_return(results)
     end

--- a/bolt-modules/boltlib/spec/functions/get_target_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_target_spec.rb
@@ -5,8 +5,6 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'get_target' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }

--- a/bolt-modules/boltlib/spec/functions/get_target_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_target_spec.rb
@@ -5,17 +5,19 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'get_target' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'with inventory' do
@@ -36,18 +38,18 @@ describe 'get_target' do
     end
 
     it 'errors when anything but a single target is returned' do
-      inventory.expects(:get_target).with(groupname).once.returns([anything, anything])
+      expect(inventory).to receive(:get_target).with(groupname).once.and_return([anything, anything])
 
       is_expected.to run.with_params(groupname)
                         .and_raise_error(Puppet::Pops::Types::TypeAssertionError)
     end
 
     it 'errors on unknown types' do
-      is_expected.to run.with_params(mock('anything')).and_raise_error(ArgumentError)
+      is_expected.to run.with_params(double('anything')).and_raise_error(ArgumentError)
     end
 
     it 'reports the call to analytics' do
-      executor.expects(:report_function_call).with('get_target')
+      expect(executor).to receive(:report_function_call).with('get_target')
       is_expected.to run.with_params(hostname).and_return(target)
     end
   end

--- a/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
@@ -9,11 +9,13 @@ describe 'get_targets' do
   let(:inventory) { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'it calls inventory get_targets' do
@@ -43,11 +45,11 @@ describe 'get_targets' do
     end
 
     it 'errors on unknown types' do
-      is_expected.to run.with_params(mock('anything')).and_raise_error(ArgumentError)
+      is_expected.to run.with_params(double('anything')).and_raise_error(ArgumentError)
     end
 
     it 'reports the call to analytics' do
-      executor.expects(:report_function_call).with('get_targets')
+      expect(executor).to receive(:report_function_call).with('get_targets')
       is_expected.to run.with_params(hostname).and_return([target])
     end
   end

--- a/bolt-modules/boltlib/spec/functions/parallelize_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/parallelize_spec.rb
@@ -7,7 +7,7 @@ require 'bolt/inventory'
 require 'bolt/plan_result'
 
 describe 'parallelize' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:array) { %w[a b c d a b a] }
   let(:future) { Bolt::PlanFuture.new(nil, 1, name: 'name', plan_id: 1234) }
@@ -15,22 +15,24 @@ describe 'parallelize' do
   let(:result_array) { %w[ea eb ec ed ea eb ea] }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, plan_stack: []) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, plan_stack: [])
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   before :each do
     array.each do
-      executor.expects(:create_future).returns(future)
+      expect(executor).to receive(:create_future).and_return(future)
     end
-    executor.expects(:wait).returns(result_array)
+    expect(executor).to receive(:wait).and_return(result_array)
   end
 
   it 'reports the function call to analytics' do
-    executor.expects(:report_function_call).with('parallelize')
+    expect(executor).to receive(:report_function_call).with('parallelize')
 
     is_expected.to(run
       .with_params(array)

--- a/bolt-modules/boltlib/spec/functions/parallelize_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/parallelize_spec.rb
@@ -7,8 +7,6 @@ require 'bolt/inventory'
 require 'bolt/plan_result'
 
 describe 'parallelize' do
-  include SpecFixtures
-
   let(:array) { %w[a b c d a b a] }
   let(:future) { Bolt::PlanFuture.new(nil, 1, name: 'name', plan_id: 1234) }
   let(:executor) { Bolt::Executor.new }
@@ -18,17 +16,14 @@ describe 'parallelize' do
   before(:each) do
     Puppet[:tasks] = tasks_enabled
     Puppet.push_context(bolt_executor: executor, plan_stack: [])
-  end
-
-  after(:each) do
-    Puppet.pop_context
-  end
-
-  before :each do
     array.each do
       expect(executor).to receive(:create_future).and_return(future)
     end
     expect(executor).to receive(:wait).and_return(result_array)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'reports the function call to analytics' do

--- a/bolt-modules/boltlib/spec/functions/puppetdb_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_command_spec.rb
@@ -4,8 +4,6 @@ require 'spec_helper'
 require 'bolt/executor'
 
 describe 'puppetdb_command' do
-  include SpecFixtures
-
   let(:executor)   { Bolt::Executor.new }
   let(:pdb_client) { double('pdb_client') }
   let(:tasks)      { true }

--- a/bolt-modules/boltlib/spec/functions/puppetdb_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_command_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 require 'bolt/executor'
 
 describe 'puppetdb_command' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor)   { Bolt::Executor.new }
-  let(:pdb_client) { mock('pdb_client') }
+  let(:pdb_client) { double('pdb_client') }
   let(:tasks)      { true }
 
   let(:command)  { 'replace_facts' }
@@ -15,20 +15,22 @@ describe 'puppetdb_command' do
   let(:version)  { 5 }
   let(:instance) { 'instance' }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks
-    Puppet.override(bolt_executor: executor, bolt_pdb_client: pdb_client) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_pdb_client: pdb_client)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'calls Bolt::PuppetDB::Client.send_command' do
-    pdb_client.expects(:send_command).with(command, version, payload, nil).returns('uuid')
+    expect(pdb_client).to receive(:send_command).with(command, version, payload, nil).and_return('uuid')
     is_expected.to run.with_params(command, version, payload)
   end
 
   it 'calls Bolt::PuppetDB::Client.send_command with a named instance' do
-    pdb_client.expects(:send_command).with(command, version, payload, instance).returns('uuid')
+    expect(pdb_client).to receive(:send_command).with(command, version, payload, instance).and_return('uuid')
     is_expected.to run.with_params(command, version, payload, instance)
   end
 
@@ -39,8 +41,8 @@ describe 'puppetdb_command' do
   end
 
   it 'reports the call to analytics' do
-    pdb_client.expects(:send_command).returns('uuid')
-    executor.expects(:report_function_call).with('puppetdb_command')
+    expect(pdb_client).to receive(:send_command).and_return('uuid')
+    expect(executor).to receive(:report_function_call).with('puppetdb_command')
     is_expected.to run.with_params(command, version, payload)
   end
 

--- a/bolt-modules/boltlib/spec/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_fact.rb
@@ -3,15 +3,17 @@
 require 'spec_helper'
 
 describe 'puppetdb_fact' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
-  let(:pdb_client) { mock('pdb_client') }
+  let(:pdb_client) { double('pdb_client') }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = true
-    Puppet.override(bolt_pdb_client: pdb_client) do
-      example.run
-    end
+    Puppet.push_context(bolt_pdb_client: pdb_client)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'it calls puppetdb_facts' do
@@ -19,13 +21,13 @@ describe 'puppetdb_fact' do
     let(:instance) { 'instance' }
 
     it 'with list of targets' do
-      pdb_client.expects(:facts_for_node).with(facts.keys).returns(facts)
+      expect(pdb_client).to receive(:facts_for_node).with(facts.keys).and_return(facts)
 
       is_expected.to run.with_params(facts.keys).and_return(facts)
     end
 
     it 'with a named instance' do
-      pdb_client.expects(:facts_for_node).with(facts.keys, instance).returns(facts)
+      expect(pdb_client).to receive(:facts_for_node).with(facts.keys, instance).and_return(facts)
 
       is_expected.to run.with_params(facts.keys, instance).and_return(facts)
     end

--- a/bolt-modules/boltlib/spec/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_fact.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 describe 'puppetdb_fact' do
-  include SpecFixtures
-
   let(:pdb_client) { double('pdb_client') }
 
   before(:each) do

--- a/bolt-modules/boltlib/spec/functions/puppetdb_query.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_query.rb
@@ -3,15 +3,17 @@
 require 'spec_helper'
 
 describe 'puppetdb_query' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
-  let(:pdb_client) { mock('pdb_client') }
+  let(:pdb_client) { double('pdb_client') }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = true
-    Puppet.override(bolt_pdb_client: pdb_client) do
-      example.run
-    end
+    Puppet.push_context(bolt_pdb_client: pdb_client)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'it calls puppetdb_facts' do
@@ -20,13 +22,13 @@ describe 'puppetdb_query' do
     let(:instance) { 'instance' }
 
     it 'with list of targets' do
-      pdb_client.expects(:make_query).with(query).returns(result)
+      expect(pdb_client).to receive(:make_query).with(query).and_return(result)
 
       is_expected.to run.with_params(query).and_return(result)
     end
 
     it 'with a named instance' do
-      pdb_client.expects(:make_query).with(query, instance).returns(result)
+      expect(pdb_client).to receive(:make_query).with(query, instance).and_return(result)
 
       is_expected.to run.with_params(query, instance).and_return(result)
     end

--- a/bolt-modules/boltlib/spec/functions/puppetdb_query.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_query.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 describe 'puppetdb_query' do
-  include SpecFixtures
-
   let(:pdb_client) { double('pdb_client') }
 
   before(:each) do

--- a/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe 'remove_from_group' do
-  include SpecFixtures
-
   let(:executor)      { Bolt::Executor.new }
   let(:config)        { Bolt::Config.default }
   let(:pal)           { nil }

--- a/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'remove_from_group' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor)      { Bolt::Executor.new }
   let(:config)        { Bolt::Config.default }
@@ -25,11 +25,13 @@ describe 'remove_from_group' do
     ] }
   end
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'errors when passed invalid data types' do
@@ -39,7 +41,7 @@ describe 'remove_from_group' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('remove_from_group')
+    expect(executor).to receive(:report_function_call).with('remove_from_group')
     is_expected.to run.with_params(target1, parent)
   end
 

--- a/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
@@ -4,8 +4,6 @@ require 'spec_helper'
 require 'bolt/plugin'
 
 describe 'resolve_references' do
-  include SpecFixtures
-
   let(:project)       { Bolt::Project.create_project('./spec/fixtures') }
   let(:config)        { Bolt::Config.new(project, {}) }
   let(:pal)           {

--- a/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'bolt/plugin'
 
 describe 'resolve_references' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:project)       { Bolt::Project.create_project('./spec/fixtures') }
   let(:config)        { Bolt::Config.new(project, {}) }
@@ -35,11 +35,13 @@ describe 'resolve_references' do
     }
   end
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'calls resolve_references' do

--- a/bolt-modules/boltlib/spec/functions/resource_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/resource_spec.rb
@@ -12,11 +12,13 @@ describe 'resource' do
   let(:hash) { { 'target' => target, 'type' => 'Package', 'title' => 'openssl' } }
   let(:resource) { Bolt::ResourceInstance.new(hash) }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = true
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'should return nil if the resource is not found' do
@@ -30,7 +32,7 @@ describe 'resource' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('resource')
+    expect(executor).to receive(:report_function_call).with('resource')
     is_expected.to run.with_params(target, 'Foo', 'bar')
   end
 end

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -8,16 +8,18 @@ require 'bolt/target'
 
 describe 'run_command' do
   let(:executor) { Bolt::Executor.new }
-  let(:inventory) { mock('inventory') }
+  let(:inventory) { double('inventory') }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      inventory.stubs(:version).returns(2)
-      inventory.stubs(:target_implementation_class).returns(Bolt::Target)
-      example.run
-    end
+    allow(inventory).to receive(:version).and_return(2)
+    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'it calls bolt executor run_command' do
@@ -28,14 +30,14 @@ describe 'run_command' do
     let(:result_set) { Bolt::ResultSet.new([result]) }
 
     before(:each) do
-      Puppet.features.stubs(:bolt?).returns(true)
+      allow(Puppet.features).to receive(:bolt?).and_return(true)
     end
 
     it 'with given command and host' do
-      executor.expects(:run_command)
+      expect(executor).to receive(:run_command)
               .with([target], command, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params(command, hostname)
@@ -43,10 +45,10 @@ describe 'run_command' do
     end
 
     it 'with given command and Target' do
-      executor.expects(:run_command)
+      expect(executor).to receive(:run_command)
               .with([target], command, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(target).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
         .with_params(command, target)
@@ -54,10 +56,10 @@ describe 'run_command' do
     end
 
     it 'with _run_as' do
-      executor.expects(:run_command)
+      expect(executor).to receive(:run_command)
               .with([target], command, { run_as: 'root' }, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(target).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
         .with_params(command, target, '_run_as' => 'root')
@@ -65,11 +67,11 @@ describe 'run_command' do
     end
 
     it 'reports the call to analytics' do
-      executor.expects(:report_function_call).with('run_command')
-      executor.expects(:run_command)
+      expect(executor).to receive(:report_function_call).with('run_command')
+      expect(executor).to receive(:run_command)
               .with([target], command, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params(command, hostname)
@@ -80,10 +82,10 @@ describe 'run_command' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:run_command)
+        expect(executor).to receive(:run_command)
                 .with([target], command, { description: message }, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params(command, target, message, {})
@@ -91,10 +93,10 @@ describe 'run_command' do
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:run_command)
+        expect(executor).to receive(:run_command)
                 .with([target], command, { description: message }, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params(command, target, message)
@@ -104,10 +106,10 @@ describe 'run_command' do
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:run_command)
+        expect(executor).to receive(:run_command)
                 .with([target], command, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params(command, target, {})
@@ -115,10 +117,10 @@ describe 'run_command' do
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:run_command)
+        expect(executor).to receive(:run_command)
                 .with([target], command, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params(command, target)
@@ -133,10 +135,10 @@ describe 'run_command' do
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 
       it 'with propagates multiple hosts and returns multiple results' do
-        executor.expects(:run_command)
+        expect(executor).to receive(:run_command)
                 .with([target, target2], command, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
         is_expected.to run
           .with_params(command, [hostname, hostname2])
@@ -144,10 +146,10 @@ describe 'run_command' do
       end
 
       it 'with propagates multiple Targets and returns multiple results' do
-        executor.expects(:run_command)
+        expect(executor).to receive(:run_command)
                 .with([target, target2], command, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with([target, target2]).returns([target, target2])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with([target, target2]).and_return([target, target2])
 
         is_expected.to run
           .with_params(command, [target, target2])
@@ -158,10 +160,10 @@ describe 'run_command' do
         let(:result2) { Bolt::Result.new(target2, error: { 'message' => hostname2 }) }
 
         it 'errors by default' do
-          executor.expects(:run_command)
+          expect(executor).to receive(:run_command)
                   .with([target, target2], command, {}, [])
-                  .returns(result_set)
-          inventory.expects(:get_targets).with([target, target2]).returns([target, target2])
+                  .and_return(result_set)
+          expect(inventory).to receive(:get_targets).with([target, target2]).and_return([target, target2])
 
           is_expected.to run
             .with_params(command, [target, target2])
@@ -169,10 +171,10 @@ describe 'run_command' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_command)
+          expect(executor).to receive(:run_command)
                   .with([target, target2], command, { catch_errors: true }, [])
-                  .returns(result_set)
-          inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
+                  .and_return(result_set)
+          expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
             .with_params(command, [hostname, hostname2], '_catch_errors' => true)
@@ -181,8 +183,8 @@ describe 'run_command' do
     end
 
     it 'without targets - does not invoke bolt' do
-      executor.expects(:run_command).never
-      inventory.expects(:get_targets).with([]).returns([])
+      expect(executor).not_to receive(:run_command)
+      expect(inventory).to receive(:get_targets).with([]).and_return([])
 
       is_expected.to run
         .with_params(command, [])
@@ -191,7 +193,7 @@ describe 'run_command' do
   end
 
   context 'running in parallel' do
-    let(:future) { mock('future') }
+    let(:future) { double('future') }
     let(:hostname) { 'test.example.com' }
     let(:target) { Bolt::Target.new(hostname) }
     let(:command) { 'hostname' }
@@ -199,10 +201,10 @@ describe 'run_command' do
     let(:result_set) { Bolt::ResultSet.new([result]) }
 
     it 'executes in a thread if the executor is in parallel mode' do
-      inventory.expects(:get_targets).with(hostname).returns([target])
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
-      executor.expects(:in_parallel?).returns(true)
-      executor.expects(:run_in_thread).returns(result_set)
+      expect(executor).to receive(:in_parallel?).and_return(true)
+      expect(executor).to receive(:run_in_thread).and_return(result_set)
 
       is_expected.to run
         .with_params(command, hostname)
@@ -240,12 +242,12 @@ describe 'run_command' do
       env_vars = { 'FRUIT' => { 'apple' => 'banana' } }
       options  = { env_vars: env_vars.transform_values(&:to_json) }
 
-      executor.expects(:run_command)
+      expect(executor).to receive(:run_command)
               .with(targets, command, options, [])
-              .returns(Bolt::ResultSet.new([]))
-      inventory.expects(:get_targets)
+              .and_return(Bolt::ResultSet.new([]))
+      expect(inventory).to receive(:get_targets)
                .with(targets)
-               .returns(targets)
+               .and_return(targets)
 
       is_expected.to run
         .with_params(command, targets, { '_env_vars' => env_vars })

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -13,8 +13,7 @@ describe 'run_command' do
 
   before(:each) do
     Puppet[:tasks] = tasks_enabled
-    allow(inventory).to receive(:version).and_return(2)
-    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    allow(inventory).to receive_messages(version: 2, target_implementation_class: Bolt::Target)
     Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
   end
 
@@ -35,8 +34,8 @@ describe 'run_command' do
 
     it 'with given command and host' do
       expect(executor).to receive(:run_command)
-              .with([target], command, {}, [])
-              .and_return(result_set)
+        .with([target], command, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -46,8 +45,8 @@ describe 'run_command' do
 
     it 'with given command and Target' do
       expect(executor).to receive(:run_command)
-              .with([target], command, {}, [])
-              .and_return(result_set)
+        .with([target], command, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
@@ -57,8 +56,8 @@ describe 'run_command' do
 
     it 'with _run_as' do
       expect(executor).to receive(:run_command)
-              .with([target], command, { run_as: 'root' }, [])
-              .and_return(result_set)
+        .with([target], command, { run_as: 'root' }, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
@@ -69,8 +68,8 @@ describe 'run_command' do
     it 'reports the call to analytics' do
       expect(executor).to receive(:report_function_call).with('run_command')
       expect(executor).to receive(:run_command)
-              .with([target], command, {}, [])
-              .and_return(result_set)
+        .with([target], command, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -83,8 +82,8 @@ describe 'run_command' do
 
       it 'passes the description through if parameters are passed' do
         expect(executor).to receive(:run_command)
-                .with([target], command, { description: message }, [])
-                .and_return(result_set)
+          .with([target], command, { description: message }, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -94,8 +93,8 @@ describe 'run_command' do
 
       it 'passes the description through if no parameters are passed' do
         expect(executor).to receive(:run_command)
-                .with([target], command, { description: message }, [])
-                .and_return(result_set)
+          .with([target], command, { description: message }, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -107,8 +106,8 @@ describe 'run_command' do
     context 'without description' do
       it 'ignores description if parameters are passed' do
         expect(executor).to receive(:run_command)
-                .with([target], command, {}, [])
-                .and_return(result_set)
+          .with([target], command, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -118,8 +117,8 @@ describe 'run_command' do
 
       it 'ignores description if no parameters are passed' do
         expect(executor).to receive(:run_command)
-                .with([target], command, {}, [])
-                .and_return(result_set)
+          .with([target], command, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -136,8 +135,8 @@ describe 'run_command' do
 
       it 'with propagates multiple hosts and returns multiple results' do
         expect(executor).to receive(:run_command)
-                .with([target, target2], command, {}, [])
-                .and_return(result_set)
+          .with([target, target2], command, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
         is_expected.to run
@@ -147,8 +146,8 @@ describe 'run_command' do
 
       it 'with propagates multiple Targets and returns multiple results' do
         expect(executor).to receive(:run_command)
-                .with([target, target2], command, {}, [])
-                .and_return(result_set)
+          .with([target, target2], command, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with([target, target2]).and_return([target, target2])
 
         is_expected.to run
@@ -161,8 +160,8 @@ describe 'run_command' do
 
         it 'errors by default' do
           expect(executor).to receive(:run_command)
-                  .with([target, target2], command, {}, [])
-                  .and_return(result_set)
+            .with([target, target2], command, {}, [])
+            .and_return(result_set)
           expect(inventory).to receive(:get_targets).with([target, target2]).and_return([target, target2])
 
           is_expected.to run
@@ -172,8 +171,8 @@ describe 'run_command' do
 
         it 'does not error with _catch_errors' do
           expect(executor).to receive(:run_command)
-                  .with([target, target2], command, { catch_errors: true }, [])
-                  .and_return(result_set)
+            .with([target, target2], command, { catch_errors: true }, [])
+            .and_return(result_set)
           expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
@@ -243,11 +242,11 @@ describe 'run_command' do
       options  = { env_vars: env_vars.transform_values(&:to_json) }
 
       expect(executor).to receive(:run_command)
-              .with(targets, command, options, [])
-              .and_return(Bolt::ResultSet.new([]))
+        .with(targets, command, options, [])
+        .and_return(Bolt::ResultSet.new([]))
       expect(inventory).to receive(:get_targets)
-               .with(targets)
-               .and_return(targets)
+        .with(targets)
+        .and_return(targets)
 
       is_expected.to run
         .with_params(command, targets, { '_env_vars' => env_vars })

--- a/bolt-modules/boltlib/spec/functions/run_container_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_container_spec.rb
@@ -32,15 +32,17 @@ describe 'run_container' do
     end
   end
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'it runs the docker command' do
-    let(:mock_status) { mock('Process::Status') }
+    let(:mock_status) { double('Process::Status') }
     let(:value) do
       { 'stdout' => "#{user}\n",
         'stderr' => "",
@@ -49,9 +51,9 @@ describe 'run_container' do
     let(:result) { Bolt::ContainerResult.new(value, object: image) }
 
     before :each do
-      Puppet.features.stubs(:bolt?).returns(true)
-      mock_status.stubs(:exitstatus).returns(0)
-      mock_status.stubs(:success?).returns(true)
+      allow(Puppet.features).to receive(:bolt?).and_return(true)
+      allow(mock_status).to receive(:exitstatus).and_return(0)
+      allow(mock_status).to receive(:success?).and_return(true)
     end
 
     it 'with given image and command' do
@@ -64,8 +66,8 @@ describe 'run_container' do
 
     context 'with errors' do
       before :each do
-        mock_status.stubs(:exitstatus).returns(127)
-        mock_status.stubs(:success?).returns(false)
+        allow(mock_status).to receive(:exitstatus).and_return(127)
+        allow(mock_status).to receive(:success?).and_return(false)
       end
 
       let(:msg) {
@@ -88,9 +90,9 @@ describe 'run_container' do
       end
 
       it 'returns a ContainerResult with errors with _catch_errors' do
-        Bolt::Util.expects(:exec_docker)
+        expect(Bolt::Util).to receive(:exec_docker)
                   .with(%W[run --rm #{image} foo])
-                  .returns(["", msg, mock_status])
+                  .and_return(["", msg, mock_status])
 
         is_expected.to run
           .with_params(image, { 'cmd' => 'foo',
@@ -102,9 +104,9 @@ describe 'run_container' do
 
     context 'with options' do
       it 'with given image and specified port' do
-        Bolt::Util.expects(:exec_docker)
+        expect(Bolt::Util).to receive(:exec_docker)
                   .with(%W[run -p 80:80 --rm #{image} whoami])
-                  .returns(["#{user}\n", "", mock_status])
+                  .and_return(["#{user}\n", "", mock_status])
 
         is_expected.to run
           .with_params(image, { 'cmd' => 'whoami',
@@ -123,9 +125,9 @@ describe 'run_container' do
         let(:dest) { '/volume_mount' }
 
         it 'with given image and specified volumes' do
-          Bolt::Util.expects(:exec_docker)
+          expect(Bolt::Util).to receive(:exec_docker)
                     .with(%W[run -v #{src}:#{dest} --rm #{image} ls /volume_mount])
-                    .returns([value['stdout'], "", mock_status])
+                    .and_return([value['stdout'], "", mock_status])
 
           is_expected.to run
             .with_params(image, { 'cmd' => "ls #{dest}",
@@ -144,9 +146,9 @@ describe 'run_container' do
         end
 
         it 'transforms values to json' do
-          Bolt::Util.expects(:exec_docker)
+          expect(Bolt::Util).to receive(:exec_docker)
                     .with(%W[run --env FRUIT={"apple":"banana"} --rm #{image} echo $FRUIT])
-                    .returns([env_vars['FRUIT'], "", mock_status])
+                    .and_return([env_vars['FRUIT'], "", mock_status])
 
           is_expected.to run
             .with_params(image, { 'cmd' => 'echo $FRUIT',
@@ -164,7 +166,7 @@ describe 'run_container' do
     end
 
     it 'reports the call to analytics' do
-      executor.expects(:report_function_call).with('run_container')
+      expect(executor).to receive(:report_function_call).with('run_container')
 
       is_expected.to run
         .with_params(image, { 'cmd' => 'whoami', 'rm' => true })

--- a/bolt-modules/boltlib/spec/functions/run_container_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_container_spec.rb
@@ -52,8 +52,7 @@ describe 'run_container' do
 
     before :each do
       allow(Puppet.features).to receive(:bolt?).and_return(true)
-      allow(mock_status).to receive(:exitstatus).and_return(0)
-      allow(mock_status).to receive(:success?).and_return(true)
+      allow(mock_status).to receive_messages(exitstatus: 0, success?: true)
     end
 
     it 'with given image and command' do
@@ -66,8 +65,7 @@ describe 'run_container' do
 
     context 'with errors' do
       before :each do
-        allow(mock_status).to receive(:exitstatus).and_return(127)
-        allow(mock_status).to receive(:success?).and_return(false)
+        allow(mock_status).to receive_messages(exitstatus: 127, success?: false)
       end
 
       let(:msg) {
@@ -91,8 +89,8 @@ describe 'run_container' do
 
       it 'returns a ContainerResult with errors with _catch_errors' do
         expect(Bolt::Util).to receive(:exec_docker)
-                  .with(%W[run --rm #{image} foo])
-                  .and_return(["", msg, mock_status])
+          .with(%W[run --rm #{image} foo])
+          .and_return(["", msg, mock_status])
 
         is_expected.to run
           .with_params(image, { 'cmd' => 'foo',
@@ -105,8 +103,8 @@ describe 'run_container' do
     context 'with options' do
       it 'with given image and specified port' do
         expect(Bolt::Util).to receive(:exec_docker)
-                  .with(%W[run -p 80:80 --rm #{image} whoami])
-                  .and_return(["#{user}\n", "", mock_status])
+          .with(%W[run -p 80:80 --rm #{image} whoami])
+          .and_return(["#{user}\n", "", mock_status])
 
         is_expected.to run
           .with_params(image, { 'cmd' => 'whoami',
@@ -126,8 +124,8 @@ describe 'run_container' do
 
         it 'with given image and specified volumes' do
           expect(Bolt::Util).to receive(:exec_docker)
-                    .with(%W[run -v #{src}:#{dest} --rm #{image} ls /volume_mount])
-                    .and_return([value['stdout'], "", mock_status])
+            .with(%W[run -v #{src}:#{dest} --rm #{image} ls /volume_mount])
+            .and_return([value['stdout'], "", mock_status])
 
           is_expected.to run
             .with_params(image, { 'cmd' => "ls #{dest}",
@@ -147,8 +145,8 @@ describe 'run_container' do
 
         it 'transforms values to json' do
           expect(Bolt::Util).to receive(:exec_docker)
-                    .with(%W[run --env FRUIT={"apple":"banana"} --rm #{image} echo $FRUIT])
-                    .and_return([env_vars['FRUIT'], "", mock_status])
+            .with(%W[run --env FRUIT={"apple":"banana"} --rm #{image} echo $FRUIT])
+            .and_return([env_vars['FRUIT'], "", mock_status])
 
           is_expected.to run
             .with_params(image, { 'cmd' => 'echo $FRUIT',

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -7,19 +7,21 @@ require 'bolt/plugin'
 require 'puppet/pops/types/p_sensitive_type'
 
 describe 'run_plan' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:tasks_enabled) { true }
   let(:inventory) { Bolt::Inventory.empty }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    executor.stubs(:noop).returns(false)
+    allow(executor).to receive(:noop).and_return(false)
 
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context "when invoked" do
@@ -46,9 +48,9 @@ describe 'run_plan' do
       end
 
       it 'run_plan(name, hash) where hash includes _run_as' do
-        executor.stubs(:run_as).returns('foo')
-        executor.expects(:run_as=).with('bar')
-        executor.expects(:run_as=).with('foo')
+        allow(executor).to receive(:run_as).and_return('foo')
+        expect(executor).to receive(:run_as=).with('bar')
+        expect(executor).to receive(:run_as=).with('foo')
 
         is_expected.to run.with_params('test::run_me', '_run_as' => 'bar').and_return('worked2')
       end
@@ -59,13 +61,13 @@ describe 'run_plan' do
     end
 
     it 'reports the function call to analytics' do
-      executor.expects(:report_function_call).with('run_plan')
-      executor.expects(:report_bundled_content).with('Plan', 'test::run_me').once
+      expect(executor).to receive(:report_function_call).with('run_plan')
+      expect(executor).to receive(:report_bundled_content).with('Plan', 'test::run_me').once
       is_expected.to run.with_params('test::run_me').and_return('worked2')
     end
 
     it 'skips reporting the function call to analytics if called internally from Bolt' do
-      executor.expects(:report_function_call).never
+      expect(executor).not_to receive(:report_function_call)
       is_expected.to run.with_params('test::run_me', '_bolt_api_call' => true).and_return('worked2')
     end
 
@@ -166,12 +168,12 @@ describe 'run_plan' do
         'string' => sensitive.new(string)
       }
 
-      sensitive.expects(:new).with(input_params['array'])
-               .returns(expected_params['array'])
-      sensitive.expects(:new).with(input_params['hash'])
-               .returns(expected_params['hash'])
-      sensitive.expects(:new).with(input_params['string'])
-               .returns(expected_params['string'])
+      expect(sensitive).to receive(:new).with(input_params['array'])
+               .and_return(expected_params['array'])
+      expect(sensitive).to receive(:new).with(input_params['hash'])
+               .and_return(expected_params['hash'])
+      expect(sensitive).to receive(:new).with(input_params['string'])
+               .and_return(expected_params['string'])
 
       is_expected.to run
         .with_params('sensitive_test', input_params.merge('_bolt_api_call' => true))
@@ -179,7 +181,7 @@ describe 'run_plan' do
     end
 
     it 'parameters are not wrapped from non-API calls' do
-      sensitive.expects(:new).never
+      expect(sensitive).not_to receive(:new)
 
       is_expected.to run
         .with_params('sensitive_test::no_api', 'string' => string)
@@ -190,7 +192,7 @@ describe 'run_plan' do
     end
 
     it 'complex parameters using Sensitive are not wrapped' do
-      sensitive.expects(:new).never
+      expect(sensitive).not_to receive(:new)
 
       is_expected.to run
         .with_params('sensitive_test::complex', 'complex' => string)

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -7,8 +7,6 @@ require 'bolt/plugin'
 require 'puppet/pops/types/p_sensitive_type'
 
 describe 'run_plan' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:tasks_enabled) { true }
   let(:inventory) { Bolt::Inventory.empty }
@@ -169,11 +167,11 @@ describe 'run_plan' do
       }
 
       expect(sensitive).to receive(:new).with(input_params['array'])
-               .and_return(expected_params['array'])
+                                        .and_return(expected_params['array'])
       expect(sensitive).to receive(:new).with(input_params['hash'])
-               .and_return(expected_params['hash'])
+                                        .and_return(expected_params['hash'])
       expect(sensitive).to receive(:new).with(input_params['string'])
-               .and_return(expected_params['string'])
+                                        .and_return(expected_params['string'])
 
       is_expected.to run
         .with_params('sensitive_test', input_params.merge('_bolt_api_call' => true))

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -7,8 +7,6 @@ require 'bolt/result'
 require 'bolt/result_set'
 
 describe 'run_script' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { double('inventory') }
   let(:tasks_enabled) { true }
@@ -17,8 +15,7 @@ describe 'run_script' do
 
   before(:each) do
     Puppet[:tasks] = tasks_enabled
-    allow(inventory).to receive(:version).and_return(2)
-    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    allow(inventory).to receive_messages(version: 2, target_implementation_class: Bolt::Target)
     Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
   end
 
@@ -38,8 +35,8 @@ describe 'run_script' do
 
     it 'with fully resolved path of file' do
       expect(executor).to receive(:run_script)
-              .with([target], full_path, [], {}, [])
-              .and_return(result_set)
+        .with([target], full_path, [], {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -65,8 +62,8 @@ describe 'run_script' do
           full_path = File.join(module_root, 'with_files/files/hostname.sh')
 
           expect(executor).to receive(:run_script)
-                  .with([target], full_path, [], {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, [], {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/hostname.sh', hostname)
@@ -81,8 +78,8 @@ describe 'run_script' do
           full_path = File.join(module_root, 'with_both/files/scripts/hostname.sh')
 
           expect(executor).to receive(:run_script)
-                  .with([target], full_path, [], {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, [], {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_both/scripts/hostname.sh', hostname)
@@ -94,8 +91,8 @@ describe 'run_script' do
           full_path = File.join(module_root, 'with_scripts/scripts/hostname.sh')
 
           expect(executor).to receive(:run_script)
-                  .with([target], full_path, [], {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, [], {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_scripts/scripts/hostname.sh', hostname)
@@ -109,8 +106,8 @@ describe 'run_script' do
           full_path = File.join(module_root, 'with_files/files/files/hostname.sh')
 
           expect(executor).to receive(:run_script)
-                  .with([target], full_path, [], {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, [], {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/files/hostname.sh', hostname)
@@ -122,8 +119,8 @@ describe 'run_script' do
           full_path = File.join(module_root, 'with_files/files/toplevel.sh')
 
           expect(executor).to receive(:run_script)
-                  .with([target], full_path, [], {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, [], {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/files/toplevel.sh', hostname)
@@ -134,8 +131,8 @@ describe 'run_script' do
 
     it 'with host given as Target' do
       expect(executor).to receive(:run_script)
-              .with([target], full_path, [], {}, [])
-              .and_return(result_set)
+        .with([target], full_path, [], {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
@@ -145,8 +142,8 @@ describe 'run_script' do
 
     it 'with given arguments as a hash of {arguments => [value]}' do
       expect(executor).to receive(:run_script)
-              .with([target], full_path, %w[hello world], {}, [])
-              .and_return(result_set)
+        .with([target], full_path, %w[hello world], {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -158,8 +155,8 @@ describe 'run_script' do
 
     it 'with given arguments as a hash of {arguments => []}' do
       expect(executor).to receive(:run_script)
-              .with([target], full_path, [], {}, [])
-              .and_return(result_set)
+        .with([target], full_path, [], {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
@@ -169,8 +166,8 @@ describe 'run_script' do
 
     it 'with pwsh_params' do
       expect(executor).to receive(:run_script)
-              .with([target], full_path, [], { pwsh_params: { 'Name' => 'BoltyMcBoltface' } }, [])
-              .and_return(result_set)
+        .with([target], full_path, [], { pwsh_params: { 'Name' => 'BoltyMcBoltface' } }, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -182,8 +179,8 @@ describe 'run_script' do
 
     it 'with _run_as' do
       expect(executor).to receive(:run_script)
-              .with([target], full_path, [], { run_as: 'root' }, [])
-              .and_return(result_set)
+        .with([target], full_path, [], { run_as: 'root' }, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
@@ -194,8 +191,8 @@ describe 'run_script' do
     it 'reports the call to analytics' do
       expect(executor).to receive(:report_function_call).with('run_script')
       expect(executor).to receive(:run_script)
-              .with([target], full_path, [], {}, [])
-              .and_return(result_set)
+        .with([target], full_path, [], {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -208,8 +205,8 @@ describe 'run_script' do
 
       it 'passes the description through if parameters are passed' do
         expect(executor).to receive(:run_script)
-                .with([target], full_path, [], { description: message }, [])
-                .and_return(result_set)
+          .with([target], full_path, [], { description: message }, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -218,8 +215,8 @@ describe 'run_script' do
 
       it 'passes the description through if no parameters are passed' do
         expect(executor).to receive(:run_script)
-                .with([target], full_path, [], { description: message }, [])
-                .and_return(result_set)
+          .with([target], full_path, [], { description: message }, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -230,8 +227,8 @@ describe 'run_script' do
     context 'without description' do
       it 'ignores description if parameters are passed' do
         expect(executor).to receive(:run_script)
-                .with([target], full_path, [], {}, [])
-                .and_return(result_set)
+          .with([target], full_path, [], {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -240,8 +237,8 @@ describe 'run_script' do
 
       it 'ignores description if no parameters are passed' do
         expect(executor).to receive(:run_script)
-                .with([target], full_path, [], {}, [])
-                .and_return(result_set)
+          .with([target], full_path, [], {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -257,8 +254,8 @@ describe 'run_script' do
 
       it 'with propagated multiple hosts and returns multiple results' do
         expect(executor).to receive(:run_script)
-                .with([target, target2], full_path, [], {}, [])
-                .and_return(result_set)
+          .with([target, target2], full_path, [], {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
         is_expected.to run
@@ -271,8 +268,8 @@ describe 'run_script' do
 
         it 'errors by default' do
           expect(executor).to receive(:run_script)
-                  .with([target, target2], full_path, [], {}, [])
-                  .and_return(result_set)
+            .with([target, target2], full_path, [], {}, [])
+            .and_return(result_set)
           expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
@@ -282,8 +279,8 @@ describe 'run_script' do
 
         it 'does not error with _catch_errors' do
           expect(executor).to receive(:run_script)
-                  .with([target, target2], full_path, [], { catch_errors: true }, [])
-                  .and_return(result_set)
+            .with([target, target2], full_path, [], { catch_errors: true }, [])
+            .and_return(result_set)
           expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
@@ -387,11 +384,11 @@ describe 'run_script' do
       options  = { env_vars: env_vars.transform_values(&:to_json) }
 
       expect(executor).to receive(:run_script)
-              .with(targets, full_path, [], options, [])
-              .and_return(Bolt::ResultSet.new([]))
+        .with(targets, full_path, [], options, [])
+        .and_return(Bolt::ResultSet.new([]))
       expect(inventory).to receive(:get_targets)
-               .with(targets)
-               .and_return(targets)
+        .with(targets)
+        .and_return(targets)
 
       is_expected.to run
         .with_params(full_path, targets, { '_env_vars' => env_vars })

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -7,21 +7,23 @@ require 'bolt/result'
 require 'bolt/result_set'
 
 describe 'run_script' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
-  let(:inventory) { mock('inventory') }
+  let(:inventory) { double('inventory') }
   let(:tasks_enabled) { true }
   let(:module_root) { File.expand_path(fixtures('modules', 'test')) }
   let(:full_path) { File.join(module_root, 'files/uploads/hostname.sh') }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      inventory.stubs(:version).returns(2)
-      inventory.stubs(:target_implementation_class).returns(Bolt::Target)
-      example.run
-    end
+    allow(inventory).to receive(:version).and_return(2)
+    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'it calls bolt executor run_script' do
@@ -31,14 +33,14 @@ describe 'run_script' do
     let(:result_set) { Bolt::ResultSet.new([result]) }
 
     before(:each) do
-      Puppet.features.stubs(:bolt?).returns(true)
+      allow(Puppet.features).to receive(:bolt?).and_return(true)
     end
 
     it 'with fully resolved path of file' do
-      executor.expects(:run_script)
+      expect(executor).to receive(:run_script)
               .with([target], full_path, [], {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads/hostname.sh', hostname)
@@ -49,7 +51,7 @@ describe 'run_script' do
       let(:module_root) { File.expand_path(fixtures('modules')) }
 
       before(:each) do
-        inventory.stubs(:get_targets).with(hostname).returns([target])
+        allow(inventory).to receive(:get_targets).with(hostname).and_return([target])
       end
 
       context 'with nonspecific module syntax' do
@@ -62,9 +64,9 @@ describe 'run_script' do
         it 'loads from files/' do
           full_path = File.join(module_root, 'with_files/files/hostname.sh')
 
-          executor.expects(:run_script)
+          expect(executor).to receive(:run_script)
                   .with([target], full_path, [], {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/hostname.sh', hostname)
@@ -78,9 +80,9 @@ describe 'run_script' do
           # Path that should be loaded from
           full_path = File.join(module_root, 'with_both/files/scripts/hostname.sh')
 
-          executor.expects(:run_script)
+          expect(executor).to receive(:run_script)
                   .with([target], full_path, [], {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_both/scripts/hostname.sh', hostname)
@@ -91,9 +93,9 @@ describe 'run_script' do
           # Path that should be loaded from
           full_path = File.join(module_root, 'with_scripts/scripts/hostname.sh')
 
-          executor.expects(:run_script)
+          expect(executor).to receive(:run_script)
                   .with([target], full_path, [], {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_scripts/scripts/hostname.sh', hostname)
@@ -106,9 +108,9 @@ describe 'run_script' do
           # Path that should be loaded from
           full_path = File.join(module_root, 'with_files/files/files/hostname.sh')
 
-          executor.expects(:run_script)
+          expect(executor).to receive(:run_script)
                   .with([target], full_path, [], {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/files/hostname.sh', hostname)
@@ -119,9 +121,9 @@ describe 'run_script' do
           # Path that should be loaded from
           full_path = File.join(module_root, 'with_files/files/toplevel.sh')
 
-          executor.expects(:run_script)
+          expect(executor).to receive(:run_script)
                   .with([target], full_path, [], {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/files/toplevel.sh', hostname)
@@ -131,10 +133,10 @@ describe 'run_script' do
     end
 
     it 'with host given as Target' do
-      executor.expects(:run_script)
+      expect(executor).to receive(:run_script)
               .with([target], full_path, [], {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(target).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads/hostname.sh', target)
@@ -142,10 +144,10 @@ describe 'run_script' do
     end
 
     it 'with given arguments as a hash of {arguments => [value]}' do
-      executor.expects(:run_script)
+      expect(executor).to receive(:run_script)
               .with([target], full_path, %w[hello world], {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads/hostname.sh',
@@ -155,10 +157,10 @@ describe 'run_script' do
     end
 
     it 'with given arguments as a hash of {arguments => []}' do
-      executor.expects(:run_script)
+      expect(executor).to receive(:run_script)
               .with([target], full_path, [], {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(target).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads/hostname.sh', target, 'arguments' => [])
@@ -166,10 +168,10 @@ describe 'run_script' do
     end
 
     it 'with pwsh_params' do
-      executor.expects(:run_script)
+      expect(executor).to receive(:run_script)
               .with([target], full_path, [], { pwsh_params: { 'Name' => 'BoltyMcBoltface' } }, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads/hostname.sh',
@@ -179,10 +181,10 @@ describe 'run_script' do
     end
 
     it 'with _run_as' do
-      executor.expects(:run_script)
+      expect(executor).to receive(:run_script)
               .with([target], full_path, [], { run_as: 'root' }, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(target).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads/hostname.sh', target, '_run_as' => 'root')
@@ -190,11 +192,11 @@ describe 'run_script' do
     end
 
     it 'reports the call to analytics' do
-      executor.expects(:report_function_call).with('run_script')
-      executor.expects(:run_script)
+      expect(executor).to receive(:report_function_call).with('run_script')
+      expect(executor).to receive(:run_script)
               .with([target], full_path, [], {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads/hostname.sh', hostname)
@@ -205,20 +207,20 @@ describe 'run_script' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:run_script)
+        expect(executor).to receive(:run_script)
                 .with([target], full_path, [], { description: message }, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params('test/uploads/hostname.sh', target, message, {})
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:run_script)
+        expect(executor).to receive(:run_script)
                 .with([target], full_path, [], { description: message }, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params('test/uploads/hostname.sh', target, message)
@@ -227,20 +229,20 @@ describe 'run_script' do
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:run_script)
+        expect(executor).to receive(:run_script)
                 .with([target], full_path, [], {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params('test/uploads/hostname.sh', target, {})
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:run_script)
+        expect(executor).to receive(:run_script)
                 .with([target], full_path, [], {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params('test/uploads/hostname.sh', target)
@@ -254,10 +256,10 @@ describe 'run_script' do
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 
       it 'with propagated multiple hosts and returns multiple results' do
-        executor.expects(:run_script)
+        expect(executor).to receive(:run_script)
                 .with([target, target2], full_path, [], {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
         is_expected.to run
           .with_params('test/uploads/hostname.sh', [hostname, hostname2])
@@ -268,10 +270,10 @@ describe 'run_script' do
         let(:result2) { Bolt::Result.new(target2, error: { 'message' => hostname2 }) }
 
         it 'errors by default' do
-          executor.expects(:run_script)
+          expect(executor).to receive(:run_script)
                   .with([target, target2], full_path, [], {}, [])
-                  .returns(result_set)
-          inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
+                  .and_return(result_set)
+          expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
             .with_params('test/uploads/hostname.sh', [hostname, hostname2])
@@ -279,10 +281,10 @@ describe 'run_script' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_script)
+          expect(executor).to receive(:run_script)
                   .with([target, target2], full_path, [], { catch_errors: true }, [])
-                  .returns(result_set)
-          inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
+                  .and_return(result_set)
+          expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
             .with_params('test/uploads/hostname.sh', [hostname, hostname2], '_catch_errors' => true)
@@ -291,8 +293,8 @@ describe 'run_script' do
     end
 
     it 'without targets - does not invoke bolt' do
-      executor.expects(:run_script).never
-      inventory.expects(:get_targets).with([]).returns([])
+      expect(executor).not_to receive(:run_script)
+      expect(inventory).to receive(:get_targets).with([]).and_return([])
 
       is_expected.to run
         .with_params('test/uploads/hostname.sh', [])
@@ -300,7 +302,7 @@ describe 'run_script' do
     end
 
     it 'errors when script is not found' do
-      executor.expects(:run_script).never
+      expect(executor).not_to receive(:run_script)
 
       is_expected.to run
         .with_params('test/uploads/nonesuch.sh', [])
@@ -308,7 +310,7 @@ describe 'run_script' do
     end
 
     it 'errors when script appoints a directory' do
-      executor.expects(:run_script).never
+      expect(executor).not_to receive(:run_script)
 
       is_expected.to run
         .with_params('test/uploads', [])
@@ -317,17 +319,17 @@ describe 'run_script' do
   end
 
   context 'running in parallel' do
-    let(:future) { mock('future') }
+    let(:future) { double('future') }
     let(:hostname) { 'test.example.com' }
     let(:target) { Bolt::Target.new(hostname) }
     let(:result) { Bolt::Result.new(target, value: { 'stdout' => hostname }) }
     let(:result_set) { Bolt::ResultSet.new([result]) }
 
     it 'executes in a thread if the executor is in parallel mode' do
-      inventory.expects(:get_targets).with(hostname).returns([target])
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
-      executor.expects(:in_parallel?).returns(true)
-      executor.expects(:run_in_thread).returns(result_set)
+      expect(executor).to receive(:in_parallel?).and_return(true)
+      expect(executor).to receive(:run_in_thread).and_return(result_set)
 
       is_expected.to run
         .with_params('test/uploads/hostname.sh', hostname)
@@ -384,12 +386,12 @@ describe 'run_script' do
       env_vars = { 'FRUIT' => { 'apple' => 'banana' } }
       options  = { env_vars: env_vars.transform_values(&:to_json) }
 
-      executor.expects(:run_script)
+      expect(executor).to receive(:run_script)
               .with(targets, full_path, [], options, [])
-              .returns(Bolt::ResultSet.new([]))
-      inventory.expects(:get_targets)
+              .and_return(Bolt::ResultSet.new([]))
+      expect(inventory).to receive(:get_targets)
                .with(targets)
-               .returns(targets)
+               .and_return(targets)
 
       is_expected.to run
         .with_params(full_path, targets, { '_env_vars' => env_vars })

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -9,33 +9,34 @@ require 'bolt/target'
 require 'puppet/pops/types/p_sensitive_type'
 require 'rspec/expectations'
 
-class TaskTypeMatcher < Mocha::ParameterMatchers::Equals
+class TaskTypeMatcher
   def initialize(executable, input_method)
-    super(nil)
     @executable = Regexp.new(executable)
     @input_method = input_method
   end
 
-  def matches?(available_parameters)
-    other = available_parameters.shift
+  # rspec-mocks uses #=== to check whether an actual argument matches.
+  def ===(other)
     @executable =~ other.files.first['path'] && @input_method == other.metadata['input_method']
   end
 end
 
 describe 'run_task' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    executor.stubs(:noop).returns(false)
+    allow(executor).to receive(:noop).and_return(false)
 
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   def mock_task(executable, input_method)
@@ -57,10 +58,10 @@ describe 'run_task' do
     it 'when running a task without metadata the input method is "both"' do
       executable = File.join(tasks_root, 'echo.sh')
 
-      executor.expects(:run_task)
+      expect(executor).to receive(:run_task)
               .with([target], mock_task(executable, nil), default_args, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('Test::Echo', hostname, default_args)
@@ -70,10 +71,10 @@ describe 'run_task' do
     it 'when running a task with metadata - the input method is specified by the metadata' do
       executable = File.join(tasks_root, 'meta.sh')
 
-      executor.expects(:run_task)
+      expect(executor).to receive(:run_task)
               .with([target], mock_task(executable, 'environment'), default_args, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('Test::Meta', hostname, default_args)
@@ -83,10 +84,10 @@ describe 'run_task' do
     it 'when called with _run_as - _run_as is passed to the executor' do
       executable = File.join(tasks_root, 'meta.sh')
 
-      executor.expects(:run_task)
+      expect(executor).to receive(:run_task)
               .with([target], mock_task(executable, 'environment'), default_args, { run_as: 'root' }, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       args = default_args.merge('_run_as' => 'root')
       is_expected.to run
@@ -97,10 +98,10 @@ describe 'run_task' do
     it 'when called without without args hash (for a task where this is allowed)' do
       executable = File.join(tasks_root, 'yes.sh')
 
-      executor.expects(:run_task)
+      expect(executor).to receive(:run_task)
               .with([target], mock_task(executable, nil), {}, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('test::yes', hostname)
@@ -116,10 +117,10 @@ describe 'run_task' do
       }
 
       expected_args = args.merge('default_string' => 'hello', 'optional_default_string' => 'goodbye')
-      executor.expects(:run_task)
+      expect(executor).to receive(:run_task)
               .with([target], mock_task(executable, 'stdin'), expected_args, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('Test::Params', hostname, args)
@@ -135,10 +136,10 @@ describe 'run_task' do
         'optional_default_string' => 'something else'
       }
 
-      executor.expects(:run_task)
+      expect(executor).to receive(:run_task)
               .with([target], mock_task(executable, 'stdin'), args, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('Test::Params', hostname, args)
@@ -155,10 +156,10 @@ describe 'run_task' do
         'undef_no_default' => nil
       }
 
-      executor.expects(:run_task)
+      expect(executor).to receive(:run_task)
               .with([target], mock_task(executable, 'environment'), expected_args, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('test::undef', hostname, args)
@@ -166,8 +167,8 @@ describe 'run_task' do
     end
 
     it 'when called with no destinations - does not invoke bolt' do
-      executor.expects(:run_task).never
-      inventory.expects(:get_targets).with([]).returns([])
+      expect(executor).not_to receive(:run_task)
+      expect(inventory).to receive(:get_targets).with([]).and_return([])
 
       is_expected.to run
         .with_params('Test::Yes', [])
@@ -175,14 +176,14 @@ describe 'run_task' do
     end
 
     it 'reports the function call and task name to analytics' do
-      executor.expects(:report_function_call).with('run_task')
-      executor.expects(:report_bundled_content).with('Task', 'Test::Echo').once
+      expect(executor).to receive(:report_function_call).with('run_task')
+      expect(executor).to receive(:report_bundled_content).with('Task', 'Test::Echo').once
       executable = File.join(tasks_root, 'echo.sh')
 
-      executor.expects(:run_task)
+      expect(executor).to receive(:run_task)
               .with([target], mock_task(executable, nil), default_args, {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('Test::Echo', hostname, default_args)
@@ -190,13 +191,13 @@ describe 'run_task' do
     end
 
     it 'skips reporting the function call to analytics if called internally from Bolt' do
-      executor.expects(:report_function_call).with('run_task').never
+      expect(executor).not_to receive(:report_function_call).with('run_task')
       executable = File.join(tasks_root, 'echo.sh')
 
-      executor.expects(:run_task)
+      expect(executor).to receive(:run_task)
               .with([target], mock_task(executable, nil), default_args, kind_of(Hash), [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('Test::Echo', hostname, default_args.merge('_bolt_api_call' => true))
@@ -217,20 +218,20 @@ describe 'run_task' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:run_task)
+        expect(executor).to receive(:run_task)
                 .with([target], anything, {}, { description: message }, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hostname).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
           .with_params('test::yes', hostname, message, {})
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:run_task)
+        expect(executor).to receive(:run_task)
                 .with([target], anything, {}, { description: message }, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hostname).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
           .with_params('test::yes', hostname, message)
@@ -239,20 +240,20 @@ describe 'run_task' do
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:run_task)
+        expect(executor).to receive(:run_task)
                 .with([target], anything, {}, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hostname).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
           .with_params('test::yes', hostname, {})
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:run_task)
+        expect(executor).to receive(:run_task)
                 .with([target], anything, {}, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hostname).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
           .with_params('test::yes', hostname)
@@ -265,10 +266,10 @@ describe 'run_task' do
       it 'targets can be specified as repeated nested arrays and strings and combine into one list of targets' do
         executable = File.join(tasks_root, 'meta.sh')
 
-        executor.expects(:run_task)
+        expect(executor).to receive(:run_task)
                 .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with([hostname, [[hostname2]], []]).returns([target, target2])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with([hostname, [[hostname2]], []]).and_return([target, target2])
 
         is_expected.to run
           .with_params('Test::Meta', [hostname, [[hostname2]], []], default_args)
@@ -278,10 +279,10 @@ describe 'run_task' do
       it 'targets can be specified as repeated nested arrays and Targets and combine into one list of targets' do
         executable = File.join(tasks_root, 'meta.sh')
 
-        executor.expects(:run_task)
+        expect(executor).to receive(:run_task)
                 .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with([target, [[target2]], []]).returns([target, target2])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with([target, [[target2]], []]).and_return([target, target2])
 
         is_expected.to run
           .with_params('Test::Meta', [target, [[target2]], []], default_args)
@@ -295,10 +296,10 @@ describe 'run_task' do
         it 'errors by default' do
           executable = File.join(tasks_root, 'meta.sh')
 
-          executor.expects(:run_task)
+          expect(executor).to receive(:run_task)
                   .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
-                  .returns(result_set)
-          inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
+                  .and_return(result_set)
+          expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
             .with_params('Test::Meta', [hostname, hostname2], default_args)
@@ -308,13 +309,13 @@ describe 'run_task' do
         it 'does not error with _catch_errors' do
           executable = File.join(tasks_root, 'meta.sh')
 
-          executor.expects(:run_task).with([target, target2],
+          expect(executor).to receive(:run_task).with([target, target2],
                                            mock_task(executable, 'environment'),
                                            default_args,
                                            { catch_errors: true },
                                            [])
-                  .returns(result_set)
-          inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
+                  .and_return(result_set)
+          expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           args = default_args.merge('_catch_errors' => true)
           is_expected.to run
@@ -325,8 +326,8 @@ describe 'run_task' do
 
     context 'when called on a module that contains manifests/init.pp' do
       it 'the call does not load init.pp' do
-        executor.expects(:run_task).never
-        inventory.expects(:get_targets).with([]).returns([])
+        expect(executor).not_to receive(:run_task)
+        expect(inventory).to receive(:get_targets).with([]).and_return([])
 
         is_expected.to run
           .with_params('test::echo', [])
@@ -337,10 +338,10 @@ describe 'run_task' do
       it 'finds task named after the module' do
         executable = File.join(tasks_root, 'init.sh')
 
-        executor.expects(:run_task)
+        expect(executor).to receive(:run_task)
                 .with([target], mock_task(executable, nil), {}, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hostname).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
           .with_params('test', hostname)
@@ -349,7 +350,7 @@ describe 'run_task' do
     end
 
     it 'when called with non existing task - reports an unknown task error' do
-      inventory.expects(:get_target).with(hostname).returns([target])
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('test::nonesuch', hostname)
@@ -382,17 +383,17 @@ describe 'run_task' do
           'sensitive_hash' => sensitive.new(sensitive_hash)
         }
 
-        sensitive.expects(:new).with(input_params['sensitive_string'])
-                 .returns(expected_params['sensitive_string'])
-        sensitive.expects(:new).with(input_params['sensitive_array'])
-                 .returns(expected_params['sensitive_array'])
-        sensitive.expects(:new).with(input_params['sensitive_hash'])
-                 .returns(expected_params['sensitive_hash'])
+        expect(sensitive).to receive(:new).with(input_params['sensitive_string'])
+                 .and_return(expected_params['sensitive_string'])
+        expect(sensitive).to receive(:new).with(input_params['sensitive_array'])
+                 .and_return(expected_params['sensitive_array'])
+        expect(sensitive).to receive(:new).with(input_params['sensitive_hash'])
+                 .and_return(expected_params['sensitive_hash'])
 
-        executor.expects(:run_task)
+        expect(executor).to receive(:run_task)
                 .with([target], mock_task(executable, nil), expected_params, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hostname).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
           .with_params('Test::Sensitive_Meta', hostname, input_params)
@@ -400,28 +401,11 @@ describe 'run_task' do
       end
     end
 
-    context 'using the pcp transport' do
-      let(:task_name)   { 'Test::Noop' }
-      let(:hostname)    { 'pcp://a.b.com' }
-      let(:task_params) { { '_noop' => true } }
-
-      it 'sets the noop metaparameter when running in noop mode' do
-        executor.expects(:run_task).with([target],
-                                         anything,
-                                         { '_noop' => true },
-                                         { noop: true },
-                                         [])
-                .returns(result_set)
-
-        is_expected.to run
-          .with_params(task_name, hostname, task_params)
-      end
-    end
   end
 
   context 'running in parallel' do
     let(:default_args) { { 'message' => 'Krabby patty' } }
-    let(:future) { mock('future') }
+    let(:future) { double('future') }
     let(:hostname) { 'a.b.com' }
     let(:result) { Bolt::Result.new(target, value: { '_output' => 'Krabby patty' }) }
     let(:result_set) { Bolt::ResultSet.new([result]) }
@@ -430,10 +414,10 @@ describe 'run_task' do
     let(:tasks_root) { File.expand_path(fixtures('modules', 'test', 'tasks')) }
 
     it 'executes in a thread if the executor is in parallel mode' do
-      inventory.expects(:get_target).with(hostname).returns([target])
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
-      executor.expects(:in_parallel?).returns(true)
-      executor.expects(:run_in_thread).returns(result_set)
+      expect(executor).to receive(:in_parallel?).and_return(true)
+      expect(executor).to receive(:run_in_thread).and_return(result_set)
 
       is_expected.to run
         .with_params('Test::Echo', hostname, default_args)

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -22,8 +22,6 @@ class TaskTypeMatcher
 end
 
 describe 'run_task' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }
@@ -59,8 +57,8 @@ describe 'run_task' do
       executable = File.join(tasks_root, 'echo.sh')
 
       expect(executor).to receive(:run_task)
-              .with([target], mock_task(executable, nil), default_args, {}, [])
-              .and_return(result_set)
+        .with([target], mock_task(executable, nil), default_args, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -72,8 +70,8 @@ describe 'run_task' do
       executable = File.join(tasks_root, 'meta.sh')
 
       expect(executor).to receive(:run_task)
-              .with([target], mock_task(executable, 'environment'), default_args, {}, [])
-              .and_return(result_set)
+        .with([target], mock_task(executable, 'environment'), default_args, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -85,8 +83,8 @@ describe 'run_task' do
       executable = File.join(tasks_root, 'meta.sh')
 
       expect(executor).to receive(:run_task)
-              .with([target], mock_task(executable, 'environment'), default_args, { run_as: 'root' }, [])
-              .and_return(result_set)
+        .with([target], mock_task(executable, 'environment'), default_args, { run_as: 'root' }, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       args = default_args.merge('_run_as' => 'root')
@@ -99,8 +97,8 @@ describe 'run_task' do
       executable = File.join(tasks_root, 'yes.sh')
 
       expect(executor).to receive(:run_task)
-              .with([target], mock_task(executable, nil), {}, {}, [])
-              .and_return(result_set)
+        .with([target], mock_task(executable, nil), {}, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -118,8 +116,8 @@ describe 'run_task' do
 
       expected_args = args.merge('default_string' => 'hello', 'optional_default_string' => 'goodbye')
       expect(executor).to receive(:run_task)
-              .with([target], mock_task(executable, 'stdin'), expected_args, {}, [])
-              .and_return(result_set)
+        .with([target], mock_task(executable, 'stdin'), expected_args, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -137,8 +135,8 @@ describe 'run_task' do
       }
 
       expect(executor).to receive(:run_task)
-              .with([target], mock_task(executable, 'stdin'), args, {}, [])
-              .and_return(result_set)
+        .with([target], mock_task(executable, 'stdin'), args, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -157,8 +155,8 @@ describe 'run_task' do
       }
 
       expect(executor).to receive(:run_task)
-              .with([target], mock_task(executable, 'environment'), expected_args, {}, [])
-              .and_return(result_set)
+        .with([target], mock_task(executable, 'environment'), expected_args, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -181,8 +179,8 @@ describe 'run_task' do
       executable = File.join(tasks_root, 'echo.sh')
 
       expect(executor).to receive(:run_task)
-              .with([target], mock_task(executable, nil), default_args, {}, [])
-              .and_return(result_set)
+        .with([target], mock_task(executable, nil), default_args, {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -195,8 +193,8 @@ describe 'run_task' do
       executable = File.join(tasks_root, 'echo.sh')
 
       expect(executor).to receive(:run_task)
-              .with([target], mock_task(executable, nil), default_args, kind_of(Hash), [])
-              .and_return(result_set)
+        .with([target], mock_task(executable, nil), default_args, kind_of(Hash), [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -219,8 +217,8 @@ describe 'run_task' do
 
       it 'passes the description through if parameters are passed' do
         expect(executor).to receive(:run_task)
-                .with([target], anything, {}, { description: message }, [])
-                .and_return(result_set)
+          .with([target], anything, {}, { description: message }, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
@@ -229,8 +227,8 @@ describe 'run_task' do
 
       it 'passes the description through if no parameters are passed' do
         expect(executor).to receive(:run_task)
-                .with([target], anything, {}, { description: message }, [])
-                .and_return(result_set)
+          .with([target], anything, {}, { description: message }, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
@@ -241,8 +239,8 @@ describe 'run_task' do
     context 'without description' do
       it 'ignores description if parameters are passed' do
         expect(executor).to receive(:run_task)
-                .with([target], anything, {}, {}, [])
-                .and_return(result_set)
+          .with([target], anything, {}, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
@@ -251,8 +249,8 @@ describe 'run_task' do
 
       it 'ignores description if no parameters are passed' do
         expect(executor).to receive(:run_task)
-                .with([target], anything, {}, {}, [])
-                .and_return(result_set)
+          .with([target], anything, {}, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
@@ -267,8 +265,8 @@ describe 'run_task' do
         executable = File.join(tasks_root, 'meta.sh')
 
         expect(executor).to receive(:run_task)
-                .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
-                .and_return(result_set)
+          .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with([hostname, [[hostname2]], []]).and_return([target, target2])
 
         is_expected.to run
@@ -280,8 +278,8 @@ describe 'run_task' do
         executable = File.join(tasks_root, 'meta.sh')
 
         expect(executor).to receive(:run_task)
-                .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
-                .and_return(result_set)
+          .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with([target, [[target2]], []]).and_return([target, target2])
 
         is_expected.to run
@@ -297,8 +295,8 @@ describe 'run_task' do
           executable = File.join(tasks_root, 'meta.sh')
 
           expect(executor).to receive(:run_task)
-                  .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
-                  .and_return(result_set)
+            .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
+            .and_return(result_set)
           expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
@@ -310,11 +308,11 @@ describe 'run_task' do
           executable = File.join(tasks_root, 'meta.sh')
 
           expect(executor).to receive(:run_task).with([target, target2],
-                                           mock_task(executable, 'environment'),
-                                           default_args,
-                                           { catch_errors: true },
-                                           [])
-                  .and_return(result_set)
+                                                      mock_task(executable, 'environment'),
+                                                      default_args,
+                                                      { catch_errors: true },
+                                                      [])
+                                                .and_return(result_set)
           expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           args = default_args.merge('_catch_errors' => true)
@@ -339,8 +337,8 @@ describe 'run_task' do
         executable = File.join(tasks_root, 'init.sh')
 
         expect(executor).to receive(:run_task)
-                .with([target], mock_task(executable, nil), {}, {}, [])
-                .and_return(result_set)
+          .with([target], mock_task(executable, nil), {}, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
@@ -384,15 +382,15 @@ describe 'run_task' do
         }
 
         expect(sensitive).to receive(:new).with(input_params['sensitive_string'])
-                 .and_return(expected_params['sensitive_string'])
+                                          .and_return(expected_params['sensitive_string'])
         expect(sensitive).to receive(:new).with(input_params['sensitive_array'])
-                 .and_return(expected_params['sensitive_array'])
+                                          .and_return(expected_params['sensitive_array'])
         expect(sensitive).to receive(:new).with(input_params['sensitive_hash'])
-                 .and_return(expected_params['sensitive_hash'])
+                                          .and_return(expected_params['sensitive_hash'])
 
         expect(executor).to receive(:run_task)
-                .with([target], mock_task(executable, nil), expected_params, {}, [])
-                .and_return(result_set)
+          .with([target], mock_task(executable, nil), expected_params, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
@@ -400,7 +398,6 @@ describe 'run_task' do
           .and_return(result_set)
       end
     end
-
   end
 
   context 'running in parallel' do

--- a/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
@@ -7,33 +7,34 @@ require 'bolt/result'
 require 'bolt/result_set'
 require 'puppet/pops/types/p_sensitive_type'
 
-class TaskTypeMatcher < Mocha::ParameterMatchers::Equals
+class TaskTypeMatcher
   def initialize(executable, input_method)
-    super(nil)
     @executable = Regexp.new(executable)
     @input_method = input_method
   end
 
-  def matches?(available_parameters)
-    other = available_parameters.shift
+  # rspec-mocks uses #=== to check whether an actual argument matches.
+  def ===(other)
     @executable =~ other.files.first['path'] && @input_method == other.metadata['input_method']
   end
 end
 
 describe 'run_task_with' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor)      { Bolt::Executor.new }
   let(:inventory)     { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    executor.stubs(:noop).returns(false)
+    allow(executor).to receive(:noop).and_return(false)
 
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   def mock_task(executable, input_method)
@@ -74,11 +75,11 @@ describe 'run_task_with' do
         target2 => { 'message' => target2.safe_name }
       }
 
-      executor.expects(:run_task_with)
+      expect(executor).to receive(:run_task_with)
               .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-              .returns(result_set)
+              .and_return(result_set)
 
-      inventory.expects(:get_targets).with(hosts).returns(targets)
+      expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
         .with_params('Test::Meta', hosts)
@@ -88,11 +89,11 @@ describe 'run_task_with' do
     it '_run_as is passed to the executor' do
       executable = File.join(tasks_root, 'meta.sh')
 
-      executor.expects(:run_task_with)
+      expect(executor).to receive(:run_task_with)
               .with(target_mapping, mock_task(executable, 'environment'), { run_as: 'root' }, [])
-              .returns(result_set)
+              .and_return(result_set)
 
-      inventory.expects(:get_targets).with(hosts).returns(targets)
+      expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
         .with_params('Test::Meta', hosts, { '_run_as' => 'root' })
@@ -119,10 +120,10 @@ describe 'run_task_with' do
         target2 => args.merge(defaults)
       }
 
-      executor.expects(:run_task_with)
+      expect(executor).to receive(:run_task_with)
               .with(target_mapping, mock_task(executable, 'stdin'), {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hosts).returns(targets)
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
         .with_params('Test::Params', hosts)
@@ -142,10 +143,10 @@ describe 'run_task_with' do
 
       target_mapping = { target => args, target2 => args }
 
-      executor.expects(:run_task_with)
+      expect(executor).to receive(:run_task_with)
               .with(target_mapping, mock_task(executable, 'stdin'), {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hosts).returns(targets)
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
         .with_params('Test::Params', hosts)
@@ -167,10 +168,10 @@ describe 'run_task_with' do
         target2 => expected_args
       }
 
-      executor.expects(:run_task_with)
+      expect(executor).to receive(:run_task_with)
               .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hosts).returns(targets)
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
         .with_params('test::undef', hosts)
@@ -178,8 +179,8 @@ describe 'run_task_with' do
     end
 
     it 'does not invoke Bolt when target list is empty' do
-      executor.expects(:run_task).never
-      inventory.expects(:get_targets).with([]).returns([])
+      expect(executor).not_to receive(:run_task)
+      expect(inventory).to receive(:get_targets).with([]).and_return([])
 
       is_expected.to(run
         .with_params('Test::Yes', [])
@@ -188,14 +189,14 @@ describe 'run_task_with' do
     end
 
     it 'reports the function call and task name to analytics' do
-      executor.expects(:report_function_call).with('run_task_with')
-      executor.expects(:report_bundled_content).with('Task', 'Test::Echo').once
+      expect(executor).to receive(:report_function_call).with('run_task_with')
+      expect(executor).to receive(:report_bundled_content).with('Task', 'Test::Echo').once
       executable = File.join(tasks_root, 'echo.sh')
 
-      executor.expects(:run_task_with)
+      expect(executor).to receive(:run_task_with)
               .with(target_mapping, mock_task(executable, nil), {}, [])
-              .returns(result_set)
-      inventory.expects(:get_targets).with(hosts).returns(targets)
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
         .with_params('Test::Echo', hosts)
@@ -207,10 +208,10 @@ describe 'run_task_with' do
       let(:message) { 'test message' }
 
       it 'passes the description through' do
-        executor.expects(:run_task_with)
+        expect(executor).to receive(:run_task_with)
                 .with(target_mapping, anything, { description: message }, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hosts).returns(targets)
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
         is_expected.to(run
           .with_params('test::yes', hosts, message)
@@ -220,10 +221,10 @@ describe 'run_task_with' do
 
     context 'without description' do
       it 'ignores description if options are passed' do
-        executor.expects(:run_task_with)
+        expect(executor).to receive(:run_task_with)
                 .with(target_mapping, anything, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hosts).returns(targets)
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
         is_expected.to(run
           .with_params('test::yes', hosts, {})
@@ -231,10 +232,10 @@ describe 'run_task_with' do
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:run_task_with)
+        expect(executor).to receive(:run_task_with)
                 .with(target_mapping, anything, {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hosts).returns(targets)
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
         is_expected.to(run
           .with_params('test::yes', hosts)
@@ -248,11 +249,11 @@ describe 'run_task_with' do
       it 'targets can be specified as repeated nested arrays and strings and combine into one list of targets' do
         executable = File.join(tasks_root, 'meta.sh')
 
-        executor.expects(:run_task_with)
+        expect(executor).to receive(:run_task_with)
                 .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-                .returns(result_set)
+                .and_return(result_set)
 
-        inventory.expects(:get_targets).with([hostname, [[hostname2]], []]).returns(targets)
+        expect(inventory).to receive(:get_targets).with([hostname, [[hostname2]], []]).and_return(targets)
 
         is_expected.to(run
           .with_params('Test::Meta', [hostname, [[hostname2]], []])
@@ -263,11 +264,11 @@ describe 'run_task_with' do
       it 'targets can be specified as repeated nested arrays and Targets and combine into one list of targets' do
         executable = File.join(tasks_root, 'meta.sh')
 
-        executor.expects(:run_task_with)
+        expect(executor).to receive(:run_task_with)
                 .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-                .returns(result_set)
+                .and_return(result_set)
 
-        inventory.expects(:get_targets).with([target, [[target2]], []]).returns(targets)
+        expect(inventory).to receive(:get_targets).with([target, [[target2]], []]).and_return(targets)
 
         is_expected.to(run
           .with_params('Test::Meta', [target, [[target2]], []])
@@ -282,11 +283,11 @@ describe 'run_task_with' do
         it 'errors by default' do
           executable = File.join(tasks_root, 'meta.sh')
 
-          executor.expects(:run_task_with)
+          expect(executor).to receive(:run_task_with)
                   .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
-          inventory.expects(:get_targets).with(hosts).returns(targets)
+          expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
           is_expected.to(run
             .with_params('Test::Meta', hosts)
@@ -297,11 +298,11 @@ describe 'run_task_with' do
         it 'does not error with _catch_errors' do
           executable = File.join(tasks_root, 'meta.sh')
 
-          executor.expects(:run_task_with)
+          expect(executor).to receive(:run_task_with)
                   .with(target_mapping, mock_task(executable, 'environment'), { catch_errors: true }, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
-          inventory.expects(:get_targets).with(hosts).returns(targets)
+          expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
           is_expected.to(run
             .with_params('Test::Meta', [hostname, hostname2], '_catch_errors' => true)
@@ -312,8 +313,8 @@ describe 'run_task_with' do
 
     context 'when called on a module that contains manifests/init.pp' do
       it 'the call does not load init.pp' do
-        executor.expects(:run_task).never
-        inventory.expects(:get_targets).with([]).returns([])
+        expect(executor).not_to receive(:run_task)
+        expect(inventory).to receive(:get_targets).with([]).and_return([])
 
         is_expected.to(run
           .with_params('test::echo', [])
@@ -327,10 +328,10 @@ describe 'run_task_with' do
       it 'finds task named after the module' do
         executable = File.join(tasks_root, 'init.sh')
 
-        executor.expects(:run_task_with)
+        expect(executor).to receive(:run_task_with)
                 .with(target_mapping, mock_task(executable, nil), {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hostname).returns([target])
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
           .with_params('test', hostname)
@@ -340,7 +341,7 @@ describe 'run_task_with' do
     end
 
     it 'when called with non existing task - reports an unknown task error' do
-      inventory.expects(:get_target).with(hostname).returns([target])
+      expect(inventory).to receive(:get_targets).with([hostname]).and_return([target])
 
       is_expected.to run
         .with_params('test::nonesuch', [hostname])
@@ -377,17 +378,17 @@ describe 'run_task_with' do
 
         target_mapping = { target => expected_params }
 
-        sensitive.expects(:new).with(input_params['sensitive_string'])
-                 .returns(expected_params['sensitive_string'])
-        sensitive.expects(:new).with(input_params['sensitive_array'])
-                 .returns(expected_params['sensitive_array'])
-        sensitive.expects(:new).with(input_params['sensitive_hash'])
-                 .returns(expected_params['sensitive_hash'])
+        expect(sensitive).to receive(:new).with(input_params['sensitive_string'])
+                 .and_return(expected_params['sensitive_string'])
+        expect(sensitive).to receive(:new).with(input_params['sensitive_array'])
+                 .and_return(expected_params['sensitive_array'])
+        expect(sensitive).to receive(:new).with(input_params['sensitive_hash'])
+                 .and_return(expected_params['sensitive_hash'])
 
-        executor.expects(:run_task_with)
+        expect(executor).to receive(:run_task_with)
                 .with(target_mapping, mock_task(executable, nil), {}, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hostname).returns(target)
+                .and_return(result_set)
+        expect(inventory).to receive(:get_targets).with(hostname).and_return(target)
 
         is_expected.to run
           .with_params('Test::Sensitive_Meta', hostname)
@@ -396,24 +397,6 @@ describe 'run_task_with' do
       end
     end
 
-    context 'using the pcp transport' do
-      let(:task_name)   { 'Test::Noop' }
-      let(:hostname)    { 'pcp://a.b.com' }
-      let(:hostname2)   { 'pcp://x.y.com' }
-      let(:task_params) { { '_noop' => true } }
-
-      it 'sets the noop metaparameter when running in noop mode' do
-        executor.expects(:run_task_with)
-                .with(target_mapping, anything, { noop: true }, [])
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hosts).returns(targets)
-
-        is_expected.to run
-          .with_params('Test::Noop', hosts, '_noop' => true)
-          .with_lambda { |_| {} }
-          .and_return(result_set)
-      end
-    end
   end
 
   context 'it validates the task parameters' do

--- a/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
@@ -20,8 +20,6 @@ class TaskTypeMatcher
 end
 
 describe 'run_task_with' do
-  include SpecFixtures
-
   let(:executor)      { Bolt::Executor.new }
   let(:inventory)     { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }
@@ -76,8 +74,8 @@ describe 'run_task_with' do
       }
 
       expect(executor).to receive(:run_task_with)
-              .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-              .and_return(result_set)
+        .with(target_mapping, mock_task(executable, 'environment'), {}, [])
+        .and_return(result_set)
 
       expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
@@ -90,8 +88,8 @@ describe 'run_task_with' do
       executable = File.join(tasks_root, 'meta.sh')
 
       expect(executor).to receive(:run_task_with)
-              .with(target_mapping, mock_task(executable, 'environment'), { run_as: 'root' }, [])
-              .and_return(result_set)
+        .with(target_mapping, mock_task(executable, 'environment'), { run_as: 'root' }, [])
+        .and_return(result_set)
 
       expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
@@ -121,8 +119,8 @@ describe 'run_task_with' do
       }
 
       expect(executor).to receive(:run_task_with)
-              .with(target_mapping, mock_task(executable, 'stdin'), {}, [])
-              .and_return(result_set)
+        .with(target_mapping, mock_task(executable, 'stdin'), {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
@@ -144,8 +142,8 @@ describe 'run_task_with' do
       target_mapping = { target => args, target2 => args }
 
       expect(executor).to receive(:run_task_with)
-              .with(target_mapping, mock_task(executable, 'stdin'), {}, [])
-              .and_return(result_set)
+        .with(target_mapping, mock_task(executable, 'stdin'), {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
@@ -169,8 +167,8 @@ describe 'run_task_with' do
       }
 
       expect(executor).to receive(:run_task_with)
-              .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-              .and_return(result_set)
+        .with(target_mapping, mock_task(executable, 'environment'), {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
@@ -194,8 +192,8 @@ describe 'run_task_with' do
       executable = File.join(tasks_root, 'echo.sh')
 
       expect(executor).to receive(:run_task_with)
-              .with(target_mapping, mock_task(executable, nil), {}, [])
-              .and_return(result_set)
+        .with(target_mapping, mock_task(executable, nil), {}, [])
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
       is_expected.to(run
@@ -209,8 +207,8 @@ describe 'run_task_with' do
 
       it 'passes the description through' do
         expect(executor).to receive(:run_task_with)
-                .with(target_mapping, anything, { description: message }, [])
-                .and_return(result_set)
+          .with(target_mapping, anything, { description: message }, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
         is_expected.to(run
@@ -222,8 +220,8 @@ describe 'run_task_with' do
     context 'without description' do
       it 'ignores description if options are passed' do
         expect(executor).to receive(:run_task_with)
-                .with(target_mapping, anything, {}, [])
-                .and_return(result_set)
+          .with(target_mapping, anything, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
         is_expected.to(run
@@ -233,8 +231,8 @@ describe 'run_task_with' do
 
       it 'ignores description if no parameters are passed' do
         expect(executor).to receive(:run_task_with)
-                .with(target_mapping, anything, {}, [])
-                .and_return(result_set)
+          .with(target_mapping, anything, {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
         is_expected.to(run
@@ -250,8 +248,8 @@ describe 'run_task_with' do
         executable = File.join(tasks_root, 'meta.sh')
 
         expect(executor).to receive(:run_task_with)
-                .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-                .and_return(result_set)
+          .with(target_mapping, mock_task(executable, 'environment'), {}, [])
+          .and_return(result_set)
 
         expect(inventory).to receive(:get_targets).with([hostname, [[hostname2]], []]).and_return(targets)
 
@@ -265,8 +263,8 @@ describe 'run_task_with' do
         executable = File.join(tasks_root, 'meta.sh')
 
         expect(executor).to receive(:run_task_with)
-                .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-                .and_return(result_set)
+          .with(target_mapping, mock_task(executable, 'environment'), {}, [])
+          .and_return(result_set)
 
         expect(inventory).to receive(:get_targets).with([target, [[target2]], []]).and_return(targets)
 
@@ -284,8 +282,8 @@ describe 'run_task_with' do
           executable = File.join(tasks_root, 'meta.sh')
 
           expect(executor).to receive(:run_task_with)
-                  .with(target_mapping, mock_task(executable, 'environment'), {}, [])
-                  .and_return(result_set)
+            .with(target_mapping, mock_task(executable, 'environment'), {}, [])
+            .and_return(result_set)
 
           expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
@@ -299,8 +297,8 @@ describe 'run_task_with' do
           executable = File.join(tasks_root, 'meta.sh')
 
           expect(executor).to receive(:run_task_with)
-                  .with(target_mapping, mock_task(executable, 'environment'), { catch_errors: true }, [])
-                  .and_return(result_set)
+            .with(target_mapping, mock_task(executable, 'environment'), { catch_errors: true }, [])
+            .and_return(result_set)
 
           expect(inventory).to receive(:get_targets).with(hosts).and_return(targets)
 
@@ -329,8 +327,8 @@ describe 'run_task_with' do
         executable = File.join(tasks_root, 'init.sh')
 
         expect(executor).to receive(:run_task_with)
-                .with(target_mapping, mock_task(executable, nil), {}, [])
-                .and_return(result_set)
+          .with(target_mapping, mock_task(executable, nil), {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
         is_expected.to run
@@ -379,15 +377,15 @@ describe 'run_task_with' do
         target_mapping = { target => expected_params }
 
         expect(sensitive).to receive(:new).with(input_params['sensitive_string'])
-                 .and_return(expected_params['sensitive_string'])
+                                          .and_return(expected_params['sensitive_string'])
         expect(sensitive).to receive(:new).with(input_params['sensitive_array'])
-                 .and_return(expected_params['sensitive_array'])
+                                          .and_return(expected_params['sensitive_array'])
         expect(sensitive).to receive(:new).with(input_params['sensitive_hash'])
-                 .and_return(expected_params['sensitive_hash'])
+                                          .and_return(expected_params['sensitive_hash'])
 
         expect(executor).to receive(:run_task_with)
-                .with(target_mapping, mock_task(executable, nil), {}, [])
-                .and_return(result_set)
+          .with(target_mapping, mock_task(executable, nil), {}, [])
+          .and_return(result_set)
         expect(inventory).to receive(:get_targets).with(hostname).and_return(target)
 
         is_expected.to run
@@ -396,7 +394,6 @@ describe 'run_task_with' do
           .and_return(result_set)
       end
     end
-
   end
 
   context 'it validates the task parameters' do

--- a/bolt-modules/boltlib/spec/functions/set_config_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_config_spec.rb
@@ -5,18 +5,20 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'set_config' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('example') }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'without tasks enabled' do
@@ -45,7 +47,7 @@ describe 'set_config' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('set_config')
+    expect(executor).to receive(:report_function_call).with('set_config')
     is_expected.to run.with_params(target, 'a', 'b').and_return(target)
   end
 end

--- a/bolt-modules/boltlib/spec/functions/set_config_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_config_spec.rb
@@ -5,8 +5,6 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'set_config' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('example') }

--- a/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
@@ -5,7 +5,7 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'set_feature' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
@@ -13,11 +13,13 @@ describe 'set_feature' do
   let(:tasks_enabled) { true }
   let(:feature) { 'feature' }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'should set a variable on a target' do
@@ -32,7 +34,7 @@ describe 'set_feature' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('set_feature')
+    expect(executor).to receive(:report_function_call).with('set_feature')
     is_expected.to run.with_params(target, feature, true).and_return(target)
   end
 

--- a/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
@@ -5,8 +5,6 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'set_feature' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('example') }

--- a/bolt-modules/boltlib/spec/functions/set_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_resources_spec.rb
@@ -9,11 +9,13 @@ describe 'set_resources' do
   let(:inventory)     { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   let(:target)    { inventory.get_target('foo') }
@@ -78,7 +80,7 @@ describe 'set_resources' do
   end
 
   it 'errors on unknown types' do
-    is_expected.to run.with_params(mock('anything')).and_raise_error(ArgumentError)
+    is_expected.to run.with_params(double('anything')).and_raise_error(ArgumentError)
   end
 
   it 'errors when setting a resource for one target on another' do
@@ -86,12 +88,12 @@ describe 'set_resources' do
   end
 
   it 'calls Target#set_resource' do
-    target.expects(:set_resource).with(resource).returns(resource)
+    expect(target).to receive(:set_resource).with(resource).and_return(resource)
     is_expected.to run.with_params(target, resource).and_return([resource])
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('set_resources')
+    expect(executor).to receive(:report_function_call).with('set_resources')
     is_expected.to run.with_params(target, resource).and_return([resource])
   end
 

--- a/bolt-modules/boltlib/spec/functions/set_var_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_var_spec.rb
@@ -5,18 +5,20 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'set_var' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('example') }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'should set a variable on a target' do
@@ -31,7 +33,7 @@ describe 'set_var' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('set_var')
+    expect(executor).to receive(:report_function_call).with('set_var')
     is_expected.to run.with_params(target, 'a', 'b').and_return(target)
   end
 

--- a/bolt-modules/boltlib/spec/functions/set_var_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_var_spec.rb
@@ -5,8 +5,6 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'set_var' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('example') }

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -7,16 +7,13 @@ require 'bolt/result_set'
 require 'bolt/target'
 
 describe 'upload_file' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { double('inventory') }
   let(:tasks_enabled) { true }
 
   before(:each) do
     Puppet[:tasks] = tasks_enabled
-    allow(inventory).to receive(:version).and_return(2)
-    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    allow(inventory).to receive_messages(version: 2, target_implementation_class: Bolt::Target)
     Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
   end
 
@@ -42,8 +39,8 @@ describe 'upload_file' do
 
     it 'with fully resolved path of file and destination' do
       expect(executor).to receive(:upload_file)
-              .with([target], full_path, destination, {}, [])
-              .and_return(result_set)
+        .with([target], full_path, destination, {}, [])
+        .and_return(result_set)
       allow(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -53,8 +50,8 @@ describe 'upload_file' do
 
     it 'with fully resolved path of directory and destination' do
       expect(executor).to receive(:upload_file)
-              .with([target], full_dir_path, destination, {}, [])
-              .and_return(result_set)
+        .with([target], full_dir_path, destination, {}, [])
+        .and_return(result_set)
       allow(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
@@ -80,8 +77,8 @@ describe 'upload_file' do
           full_path = File.join(module_root, 'with_files/files/hostname.sh')
 
           expect(executor).to receive(:upload_file)
-                  .with([target], full_path, destination, {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, destination, {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/hostname.sh', destination, hostname)
@@ -96,8 +93,8 @@ describe 'upload_file' do
           full_path = File.join(module_root, 'with_both/files/scripts/hostname.sh')
 
           expect(executor).to receive(:upload_file)
-                  .with([target], full_path, destination, {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, destination, {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_both/scripts/hostname.sh', destination, hostname)
@@ -109,8 +106,8 @@ describe 'upload_file' do
           full_path = File.join(module_root, 'with_scripts/scripts/hostname.sh')
 
           expect(executor).to receive(:upload_file)
-                  .with([target], full_path, destination, {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, destination, {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_scripts/scripts/hostname.sh', destination, hostname)
@@ -124,8 +121,8 @@ describe 'upload_file' do
           full_path = File.join(module_root, 'with_files/files/files/hostname.sh')
 
           expect(executor).to receive(:upload_file)
-                  .with([target], full_path, destination, {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, destination, {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/files/hostname.sh', destination, hostname)
@@ -137,8 +134,8 @@ describe 'upload_file' do
           full_path = File.join(module_root, 'with_files/files/toplevel.sh')
 
           expect(executor).to receive(:upload_file)
-                  .with([target], full_path, destination, {}, [])
-                  .and_return(result_set)
+            .with([target], full_path, destination, {}, [])
+            .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/files/toplevel.sh', destination, hostname)
@@ -149,8 +146,8 @@ describe 'upload_file' do
 
     it 'with target specified as a Target' do
       expect(executor).to receive(:upload_file)
-              .with([target], full_dir_path, destination, {}, [])
-              .and_return(result_set)
+        .with([target], full_dir_path, destination, {}, [])
+        .and_return(result_set)
       allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
@@ -160,8 +157,8 @@ describe 'upload_file' do
 
     it 'runs as another user' do
       expect(executor).to receive(:upload_file)
-              .with([target], full_dir_path, destination, { run_as: 'soandso' }, [])
-              .and_return(result_set)
+        .with([target], full_dir_path, destination, { run_as: 'soandso' }, [])
+        .and_return(result_set)
       allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
@@ -171,8 +168,8 @@ describe 'upload_file' do
 
     it 'reports the call to analytics' do
       expect(executor).to receive(:upload_file)
-              .with([target], full_path, destination, {}, [])
-              .and_return(result_set)
+        .with([target], full_path, destination, {}, [])
+        .and_return(result_set)
       allow(inventory).to receive(:get_targets).with(hostname).and_return([target])
       expect(executor).to receive(:report_function_call).with('upload_file')
 
@@ -186,8 +183,8 @@ describe 'upload_file' do
 
       it 'passes the description through if parameters are passed' do
         expect(executor).to receive(:upload_file)
-                .with([target], full_dir_path, destination, { description: message }, [])
-                .and_return(result_set)
+          .with([target], full_dir_path, destination, { description: message }, [])
+          .and_return(result_set)
         allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -197,8 +194,8 @@ describe 'upload_file' do
 
       it 'passes the description through if no parameters are passed' do
         expect(executor).to receive(:upload_file)
-                .with([target], full_dir_path, destination, { description: message }, [])
-                .and_return(result_set)
+          .with([target], full_dir_path, destination, { description: message }, [])
+          .and_return(result_set)
         allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -210,8 +207,8 @@ describe 'upload_file' do
     context 'without description' do
       it 'ignores description if parameters are passed' do
         expect(executor).to receive(:upload_file)
-                .with([target], full_dir_path, destination, {}, [])
-                .and_return(result_set)
+          .with([target], full_dir_path, destination, {}, [])
+          .and_return(result_set)
         allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -221,8 +218,8 @@ describe 'upload_file' do
 
       it 'ignores description if no parameters are passed' do
         expect(executor).to receive(:upload_file)
-                .with([target], full_dir_path, destination, {}, [])
-                .and_return(result_set)
+          .with([target], full_dir_path, destination, {}, [])
+          .and_return(result_set)
         allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
@@ -253,8 +250,8 @@ describe 'upload_file' do
 
         it 'errors by default' do
           expect(executor).to receive(:upload_file)
-                  .with([target, target2], full_path, destination, {}, [])
-                  .and_return(result_set)
+            .with([target, target2], full_path, destination, {}, [])
+            .and_return(result_set)
           expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
@@ -264,8 +261,8 @@ describe 'upload_file' do
 
         it 'does not error with _catch_errors' do
           expect(executor).to receive(:upload_file)
-                  .with([target, target2], full_path, destination, { catch_errors: true }, [])
-                  .and_return(result_set)
+            .with([target, target2], full_path, destination, { catch_errors: true }, [])
+            .and_return(result_set)
           expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -7,19 +7,21 @@ require 'bolt/result_set'
 require 'bolt/target'
 
 describe 'upload_file' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
-  let(:inventory) { mock('inventory') }
+  let(:inventory) { double('inventory') }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      inventory.stubs(:version).returns(2)
-      inventory.stubs(:target_implementation_class).returns(Bolt::Target)
-      example.run
-    end
+    allow(inventory).to receive(:version).and_return(2)
+    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'it calls bolt executor upload_file' do
@@ -35,14 +37,14 @@ describe 'upload_file' do
     let(:destination) { '/var/www/html' }
 
     before(:each) do
-      Puppet.features.stubs(:bolt?).returns(true)
+      allow(Puppet.features).to receive(:bolt?).and_return(true)
     end
 
     it 'with fully resolved path of file and destination' do
-      executor.expects(:upload_file)
+      expect(executor).to receive(:upload_file)
               .with([target], full_path, destination, {}, [])
-              .returns(result_set)
-      inventory.stubs(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      allow(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads/index.html', destination, hostname)
@@ -50,10 +52,10 @@ describe 'upload_file' do
     end
 
     it 'with fully resolved path of directory and destination' do
-      executor.expects(:upload_file)
+      expect(executor).to receive(:upload_file)
               .with([target], full_dir_path, destination, {}, [])
-              .returns(result_set)
-      inventory.stubs(:get_targets).with(hostname).returns([target])
+              .and_return(result_set)
+      allow(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads', destination, hostname)
@@ -64,7 +66,7 @@ describe 'upload_file' do
       let(:module_root) { File.expand_path(fixtures('modules')) }
 
       before(:each) do
-        inventory.stubs(:get_targets).with(hostname).returns([target])
+        allow(inventory).to receive(:get_targets).with(hostname).and_return([target])
       end
 
       context 'with nonspecific module syntax' do
@@ -77,9 +79,9 @@ describe 'upload_file' do
         it 'loads from files/' do
           full_path = File.join(module_root, 'with_files/files/hostname.sh')
 
-          executor.expects(:upload_file)
+          expect(executor).to receive(:upload_file)
                   .with([target], full_path, destination, {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/hostname.sh', destination, hostname)
@@ -93,9 +95,9 @@ describe 'upload_file' do
           # Path that should be loaded from
           full_path = File.join(module_root, 'with_both/files/scripts/hostname.sh')
 
-          executor.expects(:upload_file)
+          expect(executor).to receive(:upload_file)
                   .with([target], full_path, destination, {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_both/scripts/hostname.sh', destination, hostname)
@@ -106,9 +108,9 @@ describe 'upload_file' do
           # Path that should be loaded from
           full_path = File.join(module_root, 'with_scripts/scripts/hostname.sh')
 
-          executor.expects(:upload_file)
+          expect(executor).to receive(:upload_file)
                   .with([target], full_path, destination, {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_scripts/scripts/hostname.sh', destination, hostname)
@@ -121,9 +123,9 @@ describe 'upload_file' do
           # Path that should be loaded from
           full_path = File.join(module_root, 'with_files/files/files/hostname.sh')
 
-          executor.expects(:upload_file)
+          expect(executor).to receive(:upload_file)
                   .with([target], full_path, destination, {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/files/hostname.sh', destination, hostname)
@@ -134,9 +136,9 @@ describe 'upload_file' do
           # Path that should be loaded from
           full_path = File.join(module_root, 'with_files/files/toplevel.sh')
 
-          executor.expects(:upload_file)
+          expect(executor).to receive(:upload_file)
                   .with([target], full_path, destination, {}, [])
-                  .returns(result_set)
+                  .and_return(result_set)
 
           is_expected.to run
             .with_params('with_files/files/toplevel.sh', destination, hostname)
@@ -146,10 +148,10 @@ describe 'upload_file' do
     end
 
     it 'with target specified as a Target' do
-      executor.expects(:upload_file)
+      expect(executor).to receive(:upload_file)
               .with([target], full_dir_path, destination, {}, [])
-              .returns(result_set)
-      inventory.stubs(:get_targets).with(target).returns([target])
+              .and_return(result_set)
+      allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads', destination, target)
@@ -157,10 +159,10 @@ describe 'upload_file' do
     end
 
     it 'runs as another user' do
-      executor.expects(:upload_file)
+      expect(executor).to receive(:upload_file)
               .with([target], full_dir_path, destination, { run_as: 'soandso' }, [])
-              .returns(result_set)
-      inventory.stubs(:get_targets).with(target).returns([target])
+              .and_return(result_set)
+      allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run
         .with_params('test/uploads', destination, target, '_run_as' => 'soandso')
@@ -168,11 +170,11 @@ describe 'upload_file' do
     end
 
     it 'reports the call to analytics' do
-      executor.expects(:upload_file)
+      expect(executor).to receive(:upload_file)
               .with([target], full_path, destination, {}, [])
-              .returns(result_set)
-      inventory.stubs(:get_targets).with(hostname).returns([target])
-      executor.expects(:report_function_call).with('upload_file')
+              .and_return(result_set)
+      allow(inventory).to receive(:get_targets).with(hostname).and_return([target])
+      expect(executor).to receive(:report_function_call).with('upload_file')
 
       is_expected.to run
         .with_params('test/uploads/index.html', destination, hostname)
@@ -183,10 +185,10 @@ describe 'upload_file' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:upload_file)
+        expect(executor).to receive(:upload_file)
                 .with([target], full_dir_path, destination, { description: message }, [])
-                .returns(result_set)
-        inventory.stubs(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params('test/uploads', destination, target, message, {})
@@ -194,10 +196,10 @@ describe 'upload_file' do
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:upload_file)
+        expect(executor).to receive(:upload_file)
                 .with([target], full_dir_path, destination, { description: message }, [])
-                .returns(result_set)
-        inventory.stubs(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params('test/uploads', destination, target, message)
@@ -207,10 +209,10 @@ describe 'upload_file' do
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:upload_file)
+        expect(executor).to receive(:upload_file)
                 .with([target], full_dir_path, destination, {}, [])
-                .returns(result_set)
-        inventory.stubs(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params('test/uploads', destination, target, {})
@@ -218,10 +220,10 @@ describe 'upload_file' do
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:upload_file)
+        expect(executor).to receive(:upload_file)
                 .with([target], full_dir_path, destination, {}, [])
-                .returns(result_set)
-        inventory.stubs(:get_targets).with(target).returns([target])
+                .and_return(result_set)
+        allow(inventory).to receive(:get_targets).with(target).and_return([target])
 
         is_expected.to run
           .with_params('test/uploads', destination, target)
@@ -237,10 +239,10 @@ describe 'upload_file' do
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 
       it 'propagates multiple hosts and returns multiple results' do
-        executor
-          .expects(:upload_file).with([target, target2], full_path, destination, {}, [])
-          .returns(result_set)
-        inventory.stubs(:get_targets).with([hostname, hostname2]).returns([target, target2])
+        expect(executor).to receive(:upload_file)
+          .with([target, target2], full_path, destination, {}, [])
+          .and_return(result_set)
+        allow(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
         is_expected.to run.with_params('test/uploads/index.html', destination, [hostname, hostname2])
                           .and_return(result_set)
@@ -250,10 +252,10 @@ describe 'upload_file' do
         let(:result2) { Bolt::Result.new(target2, error: { 'msg' => 'oops' }) }
 
         it 'errors by default' do
-          executor.expects(:upload_file)
+          expect(executor).to receive(:upload_file)
                   .with([target, target2], full_path, destination, {}, [])
-                  .returns(result_set)
-          inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
+                  .and_return(result_set)
+          expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
             .with_params('test/uploads/index.html', destination, [hostname, hostname2])
@@ -261,10 +263,10 @@ describe 'upload_file' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:upload_file)
+          expect(executor).to receive(:upload_file)
                   .with([target, target2], full_path, destination, { catch_errors: true }, [])
-                  .returns(result_set)
-          inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
+                  .and_return(result_set)
+          expect(inventory).to receive(:get_targets).with([hostname, hostname2]).and_return([target, target2])
 
           is_expected.to run
             .with_params('test/uploads/index.html', destination, [hostname, hostname2], '_catch_errors' => true)
@@ -273,15 +275,15 @@ describe 'upload_file' do
     end
 
     it 'without targets - does not invoke bolt' do
-      executor.expects(:upload_file).never
-      inventory.expects(:get_targets).with([]).returns([])
+      expect(executor).not_to receive(:upload_file)
+      expect(inventory).to receive(:get_targets).with([]).and_return([])
 
       is_expected.to run.with_params('test/uploads/index.html', destination, [])
                         .and_return(Bolt::ResultSet.new([]))
     end
 
     it 'errors when file is not found' do
-      executor.expects(:upload_file).never
+      expect(executor).not_to receive(:upload_file)
 
       is_expected.to run.with_params('test/uploads/nonesuch.html', destination, [])
                         .and_raise_error(/No such file or directory: .*nonesuch\.html/)
@@ -289,7 +291,7 @@ describe 'upload_file' do
   end
 
   context 'running in parallel' do
-    let(:future) { mock('future') }
+    let(:future) { double('future') }
     let(:hostname) { 'test.example.com' }
     let(:target) { Bolt::Target.new(hostname) }
     let(:result) { Bolt::Result.new(target, value: { 'stdout' => hostname }) }
@@ -297,10 +299,10 @@ describe 'upload_file' do
     let(:destination) { '/var/www/html' }
 
     it 'executes in a thread if the executor is in parallel mode' do
-      inventory.expects(:get_targets).with(hostname).returns([target])
+      expect(inventory).to receive(:get_targets).with(hostname).and_return([target])
 
-      executor.expects(:in_parallel?).returns(true)
-      executor.expects(:run_in_thread).returns(result_set)
+      expect(executor).to receive(:in_parallel?).and_return(true)
+      expect(executor).to receive(:run_in_thread).and_return(result_set)
 
       is_expected.to run
         .with_params('test/uploads/index.html', destination, hostname)

--- a/bolt-modules/boltlib/spec/functions/vars_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/vars_spec.rb
@@ -5,8 +5,6 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'vars' do
-  include SpecFixtures
-
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:hostname) { 'example' }

--- a/bolt-modules/boltlib/spec/functions/vars_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/vars_spec.rb
@@ -5,18 +5,20 @@ require 'bolt/executor'
 require 'bolt/inventory'
 
 describe 'vars' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.empty }
   let(:hostname) { 'example' }
   let(:target) { inventory.get_target(hostname) }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = true
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'should return an empty hash if no vars are set' do
@@ -29,7 +31,7 @@ describe 'vars' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('vars')
+    expect(executor).to receive(:report_function_call).with('vars')
     is_expected.to run.with_params(target).and_return({})
   end
 end

--- a/bolt-modules/boltlib/spec/functions/wait_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/wait_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/executor'
 require 'bolt/plan_future'
 
 describe 'wait' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:name)      { "Pluralize" }
   let(:future)    { Bolt::PlanFuture.new('foo', name, plan_id: 1234) }
@@ -16,16 +16,18 @@ describe 'wait' do
   let(:options)   { { '_catch_errors' => true } }
   let(:sym_opts)  { { catch_errors: true } }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = true
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'reports the function call to analytics' do
-    executor.expects(:report_function_call).with('wait')
-    executor.expects(:wait).with([future]).returns(result)
+    expect(executor).to receive(:report_function_call).with('wait')
+    expect(executor).to receive(:wait).with([future]).and_return(result)
 
     is_expected.to(run
       .with_params(future))
@@ -33,15 +35,15 @@ describe 'wait' do
 
   context 'with no futures' do
     it "passes 'nil' to the executor" do
-      executor.expects(:wait).with(nil).returns(result)
+      expect(executor).to receive(:wait).with(nil).and_return(result)
 
       is_expected.to(run
         .and_return(result))
     end
 
     it 'accepts just a timeout' do
-      executor.expects(:wait)
-              .with(nil, timeout: 2).returns(result)
+      expect(executor).to receive(:wait)
+              .with(nil, timeout: 2).and_return(result)
 
       is_expected.to(run
         .with_params(2)
@@ -49,8 +51,8 @@ describe 'wait' do
     end
 
     it 'accepts just options' do
-      executor.expects(:wait)
-              .with(nil, catch_errors: true).returns(result)
+      expect(executor).to receive(:wait)
+              .with(nil, catch_errors: true).and_return(result)
 
       is_expected.to(run
         .with_params('_catch_errors' => true)
@@ -58,8 +60,8 @@ describe 'wait' do
     end
 
     it 'accepts a timeout and options' do
-      executor.expects(:wait)
-              .with(nil, timeout: 2, catch_errors: true).returns(result)
+      expect(executor).to receive(:wait)
+              .with(nil, timeout: 2, catch_errors: true).and_return(result)
 
       is_expected.to(run
         .with_params(2, '_catch_errors' => true)
@@ -68,7 +70,7 @@ describe 'wait' do
   end
 
   it 'turns a single object into an array' do
-    executor.expects(:wait).with([future]).returns(result)
+    expect(executor).to receive(:wait).with([future]).and_return(result)
 
     is_expected.to(run
       .with_params(future)
@@ -76,8 +78,8 @@ describe 'wait' do
   end
 
   it 'runs with a timeout specified' do
-    executor.expects(:wait)
-            .with([future], { timeout: timeout }).returns(result)
+    expect(executor).to receive(:wait)
+            .with([future], { timeout: timeout }).and_return(result)
 
     is_expected.to(run
       .with_params(future, timeout)
@@ -85,8 +87,8 @@ describe 'wait' do
   end
 
   it 'runs with only options specified' do
-    executor.expects(:wait)
-            .with([future], sym_opts).returns(result)
+    expect(executor).to receive(:wait)
+            .with([future], sym_opts).and_return(result)
 
     is_expected.to(run
       .with_params(future, options)
@@ -94,8 +96,8 @@ describe 'wait' do
   end
 
   it 'runs with timeout and options specified' do
-    executor.expects(:wait)
-            .with([future], sym_opts.merge({ timeout: timeout })).returns(result)
+    expect(executor).to receive(:wait)
+            .with([future], sym_opts.merge({ timeout: timeout })).and_return(result)
 
     is_expected.to(run
       .with_params(future, timeout, options)
@@ -103,8 +105,8 @@ describe 'wait' do
   end
 
   it 'filters out invalid options' do
-    executor.expects(:wait).with([future]).returns(result)
-    Bolt::Logger.expects(:warn)
+    expect(executor).to receive(:wait).with([future]).and_return(result)
+    expect(Bolt::Logger).to receive(:warn)
                 .with('plan_function_options', anything)
 
     is_expected.to(run

--- a/bolt-modules/boltlib/spec/functions/wait_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/wait_spec.rb
@@ -6,8 +6,6 @@ require 'bolt/executor'
 require 'bolt/plan_future'
 
 describe 'wait' do
-  include SpecFixtures
-
   let(:name)      { "Pluralize" }
   let(:future)    { Bolt::PlanFuture.new('foo', name, plan_id: 1234) }
   let(:executor)  { Bolt::Executor.new }
@@ -43,7 +41,7 @@ describe 'wait' do
 
     it 'accepts just a timeout' do
       expect(executor).to receive(:wait)
-              .with(nil, timeout: 2).and_return(result)
+        .with(nil, timeout: 2).and_return(result)
 
       is_expected.to(run
         .with_params(2)
@@ -52,7 +50,7 @@ describe 'wait' do
 
     it 'accepts just options' do
       expect(executor).to receive(:wait)
-              .with(nil, catch_errors: true).and_return(result)
+        .with(nil, catch_errors: true).and_return(result)
 
       is_expected.to(run
         .with_params('_catch_errors' => true)
@@ -61,7 +59,7 @@ describe 'wait' do
 
     it 'accepts a timeout and options' do
       expect(executor).to receive(:wait)
-              .with(nil, timeout: 2, catch_errors: true).and_return(result)
+        .with(nil, timeout: 2, catch_errors: true).and_return(result)
 
       is_expected.to(run
         .with_params(2, '_catch_errors' => true)
@@ -79,7 +77,7 @@ describe 'wait' do
 
   it 'runs with a timeout specified' do
     expect(executor).to receive(:wait)
-            .with([future], { timeout: timeout }).and_return(result)
+      .with([future], { timeout: timeout }).and_return(result)
 
     is_expected.to(run
       .with_params(future, timeout)
@@ -88,7 +86,7 @@ describe 'wait' do
 
   it 'runs with only options specified' do
     expect(executor).to receive(:wait)
-            .with([future], sym_opts).and_return(result)
+      .with([future], sym_opts).and_return(result)
 
     is_expected.to(run
       .with_params(future, options)
@@ -97,7 +95,7 @@ describe 'wait' do
 
   it 'runs with timeout and options specified' do
     expect(executor).to receive(:wait)
-            .with([future], sym_opts.merge({ timeout: timeout })).and_return(result)
+      .with([future], sym_opts.merge({ timeout: timeout })).and_return(result)
 
     is_expected.to(run
       .with_params(future, timeout, options)
@@ -107,7 +105,7 @@ describe 'wait' do
   it 'filters out invalid options' do
     expect(executor).to receive(:wait).with([future]).and_return(result)
     expect(Bolt::Logger).to receive(:warn)
-                .with('plan_function_options', anything)
+      .with('plan_function_options', anything)
 
     is_expected.to(run
       .with_params(future, { 'timeout' => 2 })

--- a/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
@@ -13,8 +13,7 @@ describe 'wait_until_available' do
 
   before(:each) do
     Puppet[:tasks] = tasks_enabled
-    allow(inventory).to receive(:version).and_return(2)
-    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    allow(inventory).to receive_messages(version: 2, target_implementation_class: Bolt::Target)
     Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
   end
 
@@ -36,8 +35,8 @@ describe 'wait_until_available' do
 
     it 'passes extra parameters' do
       expect(executor).to receive(:wait_until_available)
-              .with([target], description: 'desc', wait_time: 5, retry_interval: 0)
-              .and_return(result_set)
+        .with([target], description: 'desc', wait_time: 5, retry_interval: 0)
+        .and_return(result_set)
       expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run.with_params(target, 'description' => 'desc', 'wait_time' => 5, 'retry_interval' => 0)

--- a/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
@@ -6,44 +6,46 @@ require 'bolt/target'
 
 describe 'wait_until_available' do
   let(:executor) { Bolt::Executor.new }
-  let(:inventory) { mock('inventory') }
+  let(:inventory) { double('inventory') }
   let(:target) { Bolt::Target.new('test.example.com') }
   let(:tasks_enabled) { true }
   let(:result_set) { Bolt::ResultSet.new([Bolt::Result.new(target)]) }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      inventory.stubs(:version).returns(2)
-      inventory.stubs(:target_implementation_class).returns(Bolt::Target)
-      example.run
-    end
+    allow(inventory).to receive(:version).and_return(2)
+    allow(inventory).to receive(:target_implementation_class).and_return(Bolt::Target)
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'with bolt feature present' do
     before(:each) do
-      Puppet.features.stubs(:bolt?).returns(true)
+      allow(Puppet.features).to receive(:bolt?).and_return(true)
     end
 
     it 'calls executor wait_until_available' do
-      executor.expects(:wait_until_available).with([target], anything).returns(result_set)
-      inventory.expects(:get_targets).with(target).returns([target])
+      expect(executor).to receive(:wait_until_available).with([target]).and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run.with_params(target).and_return(result_set)
     end
 
     it 'passes extra parameters' do
-      executor.expects(:wait_until_available)
+      expect(executor).to receive(:wait_until_available)
               .with([target], description: 'desc', wait_time: 5, retry_interval: 0)
-              .returns(result_set)
-      inventory.expects(:get_targets).with(target).returns([target])
+              .and_return(result_set)
+      expect(inventory).to receive(:get_targets).with(target).and_return([target])
 
       is_expected.to run.with_params(target, 'description' => 'desc', 'wait_time' => 5, 'retry_interval' => 0)
                         .and_return(result_set)
     end
 
     it 'errors on unknown parameters' do
-      inventory.expects(:get_targets).with(target).returns([target])
+      expect(inventory).to receive(:get_targets).with(target).and_return([target])
       is_expected.to run.with_params(target, 'foo' => true)
                         .and_raise_error(/unknown keyword: :foo/)
     end

--- a/bolt-modules/boltlib/spec/functions/write_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/write_file_spec.rb
@@ -9,11 +9,13 @@ describe 'write_file' do
   let(:inventory) { Bolt::Inventory.empty }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor, bolt_inventory: inventory)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'without tasks enabled' do

--- a/bolt-modules/boltlib/spec/spec_helper.rb
+++ b/bolt-modules/boltlib/spec/spec_helper.rb
@@ -1,29 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'bolt/pal'
-require 'rspec-puppet'
+require_relative '../../shared_spec_helper'
 
-# Lightweight replacement for puppetlabs_spec_helper's Fixtures module:
-# fixtures('modules', 'test') resolves to spec/fixtures/modules/test.
-module SpecFixtures
-  FIXTURES_ROOT = File.expand_path('fixtures', __dir__).freeze
-
-  def fixtures(*parts)
-    File.join(FIXTURES_ROOT, *parts)
-  end
-end
-
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-Bolt::PAL.load_puppet
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path("fixtures/modules", __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!(with_bolt_pal: true)

--- a/bolt-modules/boltlib/spec/spec_helper.rb
+++ b/bolt-modules/boltlib/spec/spec_helper.rb
@@ -2,11 +2,28 @@
 
 require 'puppet_pal'
 require 'bolt/pal'
+require 'rspec-puppet'
+
+# Lightweight replacement for puppetlabs_spec_helper's Fixtures module:
+# fixtures('modules', 'test') resolves to spec/fixtures/modules/test.
+module SpecFixtures
+  FIXTURES_ROOT = File.expand_path('fixtures', __dir__).freeze
+
+  def fixtures(*parts)
+    File.join(FIXTURES_ROOT, *parts)
+  end
+end
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path("fixtures/modules", __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
 end

--- a/bolt-modules/ctrl/spec/functions/ctrl/do_until_spec.rb
+++ b/bolt-modules/ctrl/spec/functions/ctrl/do_until_spec.rb
@@ -33,7 +33,7 @@ describe 'ctrl::do_until' do
   end
 
   it 'sleeps with an interval' do
-    Kernel.expects(:sleep).with(1).times(2)
+    expect(Kernel).to receive(:sleep).with(1).twice
 
     is_expected.to(run.with_params('interval' => 1).with_lambda do
       seq.pop
@@ -44,7 +44,7 @@ describe 'ctrl::do_until' do
 
   it 'does not sleep if first value is truthy' do
     seq << 'truthy'
-    Kernel.expects(:sleep).never
+    expect(Kernel).not_to receive(:sleep)
 
     is_expected.to(run.with_params('interval' => 1).with_lambda do
       seq.pop

--- a/bolt-modules/ctrl/spec/spec_helper.rb
+++ b/bolt-modules/ctrl/spec/spec_helper.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
 require 'puppet_pal'
+require 'rspec-puppet'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path("fixtures/modules", __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
 end

--- a/bolt-modules/ctrl/spec/spec_helper.rb
+++ b/bolt-modules/ctrl/spec/spec_helper.rb
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'rspec-puppet'
+require_relative '../../shared_spec_helper'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path("fixtures/modules", __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!

--- a/bolt-modules/dir/spec/functions/dir/children_spec.rb
+++ b/bolt-modules/dir/spec/functions/dir/children_spec.rb
@@ -4,17 +4,19 @@ require 'spec_helper'
 require 'fileutils'
 
 describe 'dir::children' do
-  include PuppetlabsSpec::Fixtures
+  include SpecFixtures
 
   let(:path) { fixtures('modules', 'test') }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = true
     project = Struct.new(:name, :path, :load_as_module?).new('default', File.expand_path(path), true)
 
-    Puppet.override(bolt_project: project) do
-      example.run
-    end
+    Puppet.push_context(bolt_project: project)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   context 'finding an absolute path' do

--- a/bolt-modules/dir/spec/functions/dir/children_spec.rb
+++ b/bolt-modules/dir/spec/functions/dir/children_spec.rb
@@ -4,8 +4,6 @@ require 'spec_helper'
 require 'fileutils'
 
 describe 'dir::children' do
-  include SpecFixtures
-
   let(:path) { fixtures('modules', 'test') }
 
   before(:each) do

--- a/bolt-modules/dir/spec/spec_helper.rb
+++ b/bolt-modules/dir/spec/spec_helper.rb
@@ -1,10 +1,27 @@
 # frozen_string_literal: true
 
 require 'puppet_pal'
+require 'rspec-puppet'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+
+# Lightweight replacement for puppetlabs_spec_helper's Fixtures module:
+# fixtures('modules', 'test') resolves to spec/fixtures/modules/test.
+module SpecFixtures
+  FIXTURES_ROOT = File.expand_path('fixtures', __dir__).freeze
+
+  def fixtures(*parts)
+    File.join(FIXTURES_ROOT, *parts)
+  end
+end
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path("fixtures/modules", __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
 end

--- a/bolt-modules/dir/spec/spec_helper.rb
+++ b/bolt-modules/dir/spec/spec_helper.rb
@@ -1,27 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'rspec-puppet'
+require_relative '../../shared_spec_helper'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-
-# Lightweight replacement for puppetlabs_spec_helper's Fixtures module:
-# fixtures('modules', 'test') resolves to spec/fixtures/modules/test.
-module SpecFixtures
-  FIXTURES_ROOT = File.expand_path('fixtures', __dir__).freeze
-
-  def fixtures(*parts)
-    File.join(FIXTURES_ROOT, *parts)
-  end
-end
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path("fixtures/modules", __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!

--- a/bolt-modules/file/spec/functions/file/exists_spec.rb
+++ b/bolt-modules/file/spec/functions/file/exists_spec.rb
@@ -4,10 +4,12 @@ require 'bolt/executor'
 require 'spec_helper'
 
 describe 'file::exists' do
-  around(:each) do |example|
-    Puppet.override({ bolt_executor: executor }) do
-      example.run
-    end
+  before(:each) do
+    Puppet.push_context({ bolt_executor: executor })
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   shared_examples "file loading" do

--- a/bolt-modules/file/spec/functions/file/join_spec.rb
+++ b/bolt-modules/file/spec/functions/file/join_spec.rb
@@ -6,9 +6,13 @@ require 'bolt/executor'
 describe 'file::join' do
   let(:executor) { Bolt::Executor.new }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = true
-    Puppet.override(bolt_executor: executor) { example.run }
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'joins file paths' do
@@ -16,7 +20,7 @@ describe 'file::join' do
   end
 
   it 'reports function call to analytics' do
-    executor.expects(:report_function_call).with('file::join')
+    expect(executor).to receive(:report_function_call).with('file::join')
     is_expected.to run.with_params('foo', 'bar', 'bak')
   end
 end

--- a/bolt-modules/file/spec/functions/file/read_spec.rb
+++ b/bolt-modules/file/spec/functions/file/read_spec.rb
@@ -4,10 +4,12 @@ require 'bolt/executor'
 require 'spec_helper'
 
 describe 'file::read' do
-  around(:each) do |example|
-    Puppet.override({ bolt_executor: executor }) do
-      example.run
-    end
+  before(:each) do
+    Puppet.push_context({ bolt_executor: executor })
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   shared_examples 'file loading' do

--- a/bolt-modules/file/spec/functions/file/readable_spec.rb
+++ b/bolt-modules/file/spec/functions/file/readable_spec.rb
@@ -4,10 +4,12 @@ require 'bolt/executor'
 require 'spec_helper'
 
 describe 'file::readable' do
-  around(:each) do |example|
-    Puppet.override({ bolt_executor: executor }) do
-      example.run
-    end
+  before(:each) do
+    Puppet.push_context({ bolt_executor: executor })
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   shared_examples 'file loading' do

--- a/bolt-modules/file/spec/spec_helper.rb
+++ b/bolt-modules/file/spec/spec_helper.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
 require 'puppet_pal'
+require 'rspec-puppet'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path("fixtures/modules", __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
 end

--- a/bolt-modules/file/spec/spec_helper.rb
+++ b/bolt-modules/file/spec/spec_helper.rb
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'rspec-puppet'
+require_relative '../../shared_spec_helper'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path("fixtures/modules", __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!

--- a/bolt-modules/log/spec/functions/log/debug_spec.rb
+++ b/bolt-modules/log/spec/functions/log/debug_spec.rb
@@ -3,19 +3,21 @@
 require 'spec_helper'
 
 describe 'log::debug' do
-  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:executor)      { double('executor', report_function_call: nil, publish_event: nil) }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
 
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'sends a log event to the executor' do
-    executor.expects(:publish_event).with(
+    expect(executor).to receive(:publish_event).with(
       type:    :log,
       level:   :debug,
       message: 'This is a debug message'
@@ -25,7 +27,7 @@ describe 'log::debug' do
   end
 
   it 'reports function call to analytics' do
-    executor.expects(:report_function_call).with('log::debug')
+    expect(executor).to receive(:report_function_call).with('log::debug')
     is_expected.to run.with_params('This is a debug message')
   end
 

--- a/bolt-modules/log/spec/functions/log/error_spec.rb
+++ b/bolt-modules/log/spec/functions/log/error_spec.rb
@@ -3,19 +3,21 @@
 require 'spec_helper'
 
 describe 'log::error' do
-  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:executor)      { double('executor', report_function_call: nil, publish_event: nil) }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
 
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'sends a log event to the executor' do
-    executor.expects(:publish_event).with(
+    expect(executor).to receive(:publish_event).with(
       type:    :log,
       level:   :error,
       message: 'This is an error message'
@@ -25,7 +27,7 @@ describe 'log::error' do
   end
 
   it 'reports function call to analytics' do
-    executor.expects(:report_function_call).with('log::error')
+    expect(executor).to receive(:report_function_call).with('log::error')
     is_expected.to run.with_params('This is an error message')
   end
 

--- a/bolt-modules/log/spec/functions/log/fatal_spec.rb
+++ b/bolt-modules/log/spec/functions/log/fatal_spec.rb
@@ -3,19 +3,21 @@
 require 'spec_helper'
 
 describe 'log::fatal' do
-  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:executor)      { double('executor', report_function_call: nil, publish_event: nil) }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
 
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'sends a log event to the executor' do
-    executor.expects(:publish_event).with(
+    expect(executor).to receive(:publish_event).with(
       type:    :log,
       level:   :fatal,
       message: 'This is a fatal message'
@@ -25,7 +27,7 @@ describe 'log::fatal' do
   end
 
   it 'reports function call to analytics' do
-    executor.expects(:report_function_call).with('log::fatal')
+    expect(executor).to receive(:report_function_call).with('log::fatal')
     is_expected.to run.with_params('This is a fatal message')
   end
 

--- a/bolt-modules/log/spec/functions/log/info_spec.rb
+++ b/bolt-modules/log/spec/functions/log/info_spec.rb
@@ -3,19 +3,21 @@
 require 'spec_helper'
 
 describe 'log::info' do
-  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:executor)      { double('executor', report_function_call: nil, publish_event: nil) }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
 
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'sends a log event to the executor' do
-    executor.expects(:publish_event).with(
+    expect(executor).to receive(:publish_event).with(
       type:    :log,
       level:   :info,
       message: 'This is an info message'
@@ -25,7 +27,7 @@ describe 'log::info' do
   end
 
   it 'reports function call to analytics' do
-    executor.expects(:report_function_call).with('log::info')
+    expect(executor).to receive(:report_function_call).with('log::info')
     is_expected.to run.with_params('This is an info message')
   end
 

--- a/bolt-modules/log/spec/functions/log/trace_spec.rb
+++ b/bolt-modules/log/spec/functions/log/trace_spec.rb
@@ -3,19 +3,21 @@
 require 'spec_helper'
 
 describe 'log::trace' do
-  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:executor)      { double('executor', report_function_call: nil, publish_event: nil) }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
 
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'sends a log event to the executor' do
-    executor.expects(:publish_event).with(
+    expect(executor).to receive(:publish_event).with(
       type:    :log,
       level:   :trace,
       message: 'This is a trace message'
@@ -25,7 +27,7 @@ describe 'log::trace' do
   end
 
   it 'reports function call to analytics' do
-    executor.expects(:report_function_call).with('log::trace')
+    expect(executor).to receive(:report_function_call).with('log::trace')
     is_expected.to run.with_params('This is a trace message')
   end
 

--- a/bolt-modules/log/spec/functions/log/warn_spec.rb
+++ b/bolt-modules/log/spec/functions/log/warn_spec.rb
@@ -3,19 +3,21 @@
 require 'spec_helper'
 
 describe 'log::warn' do
-  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:executor)      { double('executor', report_function_call: nil, publish_event: nil) }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
 
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'sends a log event to the executor' do
-    executor.expects(:publish_event).with(
+    expect(executor).to receive(:publish_event).with(
       type:    :log,
       level:   :warn,
       message: 'This is a warn message'
@@ -25,7 +27,7 @@ describe 'log::warn' do
   end
 
   it 'reports function call to analytics' do
-    executor.expects(:report_function_call).with('log::warn')
+    expect(executor).to receive(:report_function_call).with('log::warn')
     is_expected.to run.with_params('This is a warn message')
   end
 

--- a/bolt-modules/log/spec/spec_helper.rb
+++ b/bolt-modules/log/spec/spec_helper.rb
@@ -1,19 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'bolt/pal'
-require 'rspec-puppet'
+require_relative '../../shared_spec_helper'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-Bolt::PAL.load_puppet
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path("fixtures/modules", __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!(with_bolt_pal: true)

--- a/bolt-modules/log/spec/spec_helper.rb
+++ b/bolt-modules/log/spec/spec_helper.rb
@@ -2,11 +2,18 @@
 
 require 'puppet_pal'
 require 'bolt/pal'
+require 'rspec-puppet'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path("fixtures/modules", __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
 end

--- a/bolt-modules/out/spec/functions/out/message_spec.rb
+++ b/bolt-modules/out/spec/functions/out/message_spec.rb
@@ -3,19 +3,21 @@
 require 'spec_helper'
 
 describe 'out::message' do
-  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:executor)      { double('executor', report_function_call: nil, publish_event: nil) }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
 
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'sends a message event to the executor' do
-    executor.expects(:publish_event).with(
+    expect(executor).to receive(:publish_event).with(
       type:    :message,
       message: 'This is a message',
       level:   :info
@@ -25,7 +27,7 @@ describe 'out::message' do
   end
 
   it 'reports function call to analytics' do
-    executor.expects(:report_function_call).with('out::message')
+    expect(executor).to receive(:report_function_call).with('out::message')
     is_expected.to run.with_params('This is a message')
   end
 

--- a/bolt-modules/out/spec/functions/out/verbose_spec.rb
+++ b/bolt-modules/out/spec/functions/out/verbose_spec.rb
@@ -3,19 +3,21 @@
 require 'spec_helper'
 
 describe 'out::verbose' do
-  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:executor)      { double('executor', report_function_call: nil, publish_event: nil) }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
 
-    Puppet.override(bolt_executor: executor) do
-      example.run
-    end
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'sends a verbose event to the executor' do
-    executor.expects(:publish_event).with(
+    expect(executor).to receive(:publish_event).with(
       type:    :verbose,
       message: 'This is a message',
       level:   :debug
@@ -25,7 +27,7 @@ describe 'out::verbose' do
   end
 
   it 'reports function call to analytics' do
-    executor.expects(:report_function_call).with('out::verbose')
+    expect(executor).to receive(:report_function_call).with('out::verbose')
     is_expected.to run.with_params('This is a message')
   end
 

--- a/bolt-modules/out/spec/spec_helper.rb
+++ b/bolt-modules/out/spec/spec_helper.rb
@@ -1,19 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'bolt/pal'
-require 'rspec-puppet'
+require_relative '../../shared_spec_helper'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-Bolt::PAL.load_puppet
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path("fixtures/modules", __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!(with_bolt_pal: true)

--- a/bolt-modules/out/spec/spec_helper.rb
+++ b/bolt-modules/out/spec/spec_helper.rb
@@ -2,11 +2,18 @@
 
 require 'puppet_pal'
 require 'bolt/pal'
+require 'rspec-puppet'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path("fixtures/modules", __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
 end

--- a/bolt-modules/prompt/spec/functions/prompt/menu_spec.rb
+++ b/bolt-modules/prompt/spec/functions/prompt/menu_spec.rb
@@ -7,9 +7,13 @@ describe 'prompt::menu' do
   let(:executor)      { Bolt::Executor.new }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor) { example.run }
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'displays a menu from an array of options' do
@@ -20,7 +24,7 @@ describe 'prompt::menu' do
       Select a fruit
     PROMPT
 
-    executor.expects(:prompt).with(prompt, {}).returns('1')
+    expect(executor).to receive(:prompt).with(prompt, {}).and_return('1')
 
     is_expected.to run
       .with_params('Select a fruit', %w[apple banana carrot])
@@ -35,7 +39,7 @@ describe 'prompt::menu' do
       Select a fruit
     PROMPT
 
-    executor.expects(:prompt).with(prompt, {}).returns('a')
+    expect(executor).to receive(:prompt).with(prompt, {}).and_return('a')
 
     is_expected.to run
       .with_params('Select a fruit', { 'a' => 'apple', 'b' => 'banana', 'c' => 'carrot' })
@@ -50,7 +54,7 @@ describe 'prompt::menu' do
       Select a fruit
     PROMPT
 
-    executor.expects(:prompt).with(prompt, {}).returns('a')
+    expect(executor).to receive(:prompt).with(prompt, {}).and_return('a')
 
     is_expected.to run
       .with_params('Select a fruit', { 'a' => 'apple', 'b' => 'banana', 'carrot' => 'carrot' })
@@ -58,9 +62,9 @@ describe 'prompt::menu' do
   end
 
   it 'returns a default value if no input is provided' do
-    $stdin.expects(:tty?).returns(true)
-    $stdin.expects(:gets).returns('')
-    $stderr.expects(:print)
+    expect($stdin).to receive(:tty?).and_return(true)
+    expect($stdin).to receive(:gets).and_return('')
+    expect($stderr).to receive(:print)
 
     is_expected.to run
       .with_params('Select a fruit', %w[apple banana carrot], 'default' => 'apple')
@@ -74,8 +78,8 @@ describe 'prompt::menu' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('prompt::menu')
-    executor.expects(:prompt).with("(1) apple\nSelect a fruit", {}).returns('1')
+    expect(executor).to receive(:report_function_call).with('prompt::menu')
+    expect(executor).to receive(:prompt).with("(1) apple\nSelect a fruit", {}).and_return('1')
     is_expected.to run.with_params('Select a fruit', ['apple'])
   end
 

--- a/bolt-modules/prompt/spec/functions/prompt_spec.rb
+++ b/bolt-modules/prompt/spec/functions/prompt_spec.rb
@@ -9,18 +9,22 @@ describe 'prompt' do
   let(:response)      { 'response' }
   let(:tasks_enabled) { true }
 
-  around(:each) do |example|
+  before(:each) do
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor) { example.run }
+    Puppet.push_context(bolt_executor: executor)
+  end
+
+  after(:each) do
+    Puppet.pop_context
   end
 
   it 'returns a String value' do
-    executor.expects(:prompt).with(prompt, {}).returns(response)
+    expect(executor).to receive(:prompt).with(prompt, {}).and_return(response)
     is_expected.to run.with_params(prompt).and_return(response)
   end
 
   it 'returns a Sensitive value' do
-    executor.expects(:prompt).with(prompt, sensitive: true).returns(response)
+    expect(executor).to receive(:prompt).with(prompt, { sensitive: true }).and_return(response)
 
     result = subject.execute(prompt, 'sensitive' => true)
 
@@ -29,9 +33,9 @@ describe 'prompt' do
   end
 
   it 'returns a default value if no input is provided' do
-    $stdin.expects(:tty?).returns(true)
-    $stdin.expects(:gets).returns('')
-    $stderr.expects(:print)
+    expect($stdin).to receive(:tty?).and_return(true)
+    expect($stdin).to receive(:gets).and_return('')
+    expect($stderr).to receive(:print)
 
     is_expected.to run.with_params(prompt, 'default' => response).and_return(response)
   end
@@ -49,8 +53,8 @@ describe 'prompt' do
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('prompt')
-    executor.expects(:prompt).with(prompt, {}).returns(response)
+    expect(executor).to receive(:report_function_call).with('prompt')
+    expect(executor).to receive(:prompt).with(prompt, {}).and_return(response)
     is_expected.to run.with_params(prompt)
   end
 

--- a/bolt-modules/prompt/spec/spec_helper.rb
+++ b/bolt-modules/prompt/spec/spec_helper.rb
@@ -2,11 +2,19 @@
 
 require 'puppet_pal'
 require 'bolt/pal'
+require 'bolt/target'
+require 'rspec-puppet'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path("fixtures/modules", __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
 end

--- a/bolt-modules/prompt/spec/spec_helper.rb
+++ b/bolt-modules/prompt/spec/spec_helper.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'bolt/pal'
+require_relative '../../shared_spec_helper'
 require 'bolt/target'
-require 'rspec-puppet'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-Bolt::PAL.load_puppet
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path("fixtures/modules", __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!(with_bolt_pal: true)

--- a/bolt-modules/shared_spec_helper.rb
+++ b/bolt-modules/shared_spec_helper.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Shared spec helper for each bundled Bolt module under bolt-modules/ and
+# modules/, plus bolt_spec_spec/. Each module's spec/spec_helper.rb loads
+# this file and calls configure_rspec_for_this_module!.
+
+require 'rspec-puppet'
+require 'puppet_pal'
+
+BOLT_REPO_ROOT = File.expand_path('..', __dir__)
+
+# Lightweight replacement for puppetlabs_spec_helper's Fixtures#fixtures:
+# returns the path to spec/fixtures/<parts> under the current module.
+# Callers assume tests run with cwd at the module root (which ci:modules
+# arranges).
+def fixtures(*parts)
+  File.join('spec', 'fixtures', *parts)
+end
+
+# Configure rspec-puppet to resolve Puppet modules by pointing at the real
+# bolt-modules/ and modules/ directories directly (no symlinking into
+# spec/fixtures/modules). Each module's own spec/fixtures/modules is also
+# on the path for test-specific fixture modules.
+#
+# with_bolt_pal - set to true for modules whose specs require Bolt::PAL
+#                 to be loaded before puppet functions are evaluated.
+def configure_rspec_for_this_module!(with_bolt_pal: false, extra_module_paths: [])
+  Puppet[:tasks] = true
+
+  if with_bolt_pal
+    require 'bolt/pal'
+    Bolt::PAL.load_puppet
+  end
+
+  caller_spec_dir = File.dirname(caller_locations(1, 1).first.path)
+
+  RSpec.configure do |c|
+    c.module_path = ([
+      File.join(caller_spec_dir, 'fixtures', 'modules'),
+      File.join(BOLT_REPO_ROOT, 'bolt-modules'),
+      File.join(BOLT_REPO_ROOT, 'modules')
+    ] + extra_module_paths).join(File::PATH_SEPARATOR)
+
+    # voxpupuli-test turns these on by default. Bolt's module specs were not
+    # written against strict variables, and they rely on the real Facter to
+    # resolve facts at plan-evaluation time.
+    c.strict_variables = false
+    c.facter_implementation = :facter if c.respond_to?(:facter_implementation=)
+  end
+end

--- a/bolt-modules/system/spec/spec_helper.rb
+++ b/bolt-modules/system/spec/spec_helper.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
 require 'puppet_pal'
+require 'rspec-puppet'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path("fixtures/modules", __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
 end

--- a/bolt-modules/system/spec/spec_helper.rb
+++ b/bolt-modules/system/spec/spec_helper.rb
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'rspec-puppet'
+require_relative '../../shared_spec_helper'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path("fixtures/modules", __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!

--- a/bolt_spec_spec/spec/spec_helper.rb
+++ b/bolt_spec_spec/spec/spec_helper.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
-require 'rspec-puppet'
+$LOAD_PATH.unshift File.expand_path('../../lib', __dir__)
+require_relative '../../bolt-modules/shared_spec_helper'
 
-$LOAD_PATH.unshift File.join(__dir__, '..', '..', 'lib')
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../..', __dir__)
-  c.module_path = [
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules'),
-    repo_root
-  ].join(File::PATH_SEPARATOR)
-end
+# bolt_spec_spec lives directly under the repo root, so we need the repo root
+# on the modulepath for the bolt_spec_spec module itself to be discoverable.
+configure_rspec_for_this_module!(extra_module_paths: [BOLT_REPO_ROOT])

--- a/bolt_spec_spec/spec/spec_helper.rb
+++ b/bolt_spec_spec/spec/spec_helper.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
-RSpec.configure do |c|
-  c.mock_with :mocha
-end
+require 'rspec-puppet'
+
 $LOAD_PATH.unshift File.join(__dir__, '..', '..', 'lib')
-require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+  repo_root = File.expand_path('../..', __dir__)
+  c.module_path = [
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules'),
+    repo_root
+  ].join(File::PATH_SEPARATOR)
+end

--- a/modules/aggregate/.fixtures.yml
+++ b/modules/aggregate/.fixtures.yml
@@ -1,5 +1,0 @@
----
-fixtures:
-  symlinks:
-    aggregate: "#{source_dir}"
-    boltlib: "#{File.absolute_path(File.join(source_dir, '..', '..', 'bolt-modules', 'boltlib'))}"

--- a/modules/aggregate/spec/spec_helper.rb
+++ b/modules/aggregate/spec/spec_helper.rb
@@ -1,10 +1,30 @@
 # frozen_string_literal: true
 
 require 'puppet_pal'
+require 'rspec-puppet'
+require 'bolt_spec/plans'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path('fixtures/modules', __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
+end
+
+# BoltSpec::BoltContext#modulepath wraps RSpec.configuration.module_path in
+# a single-element array, which leaves colon-separated paths joined and
+# unsplittable by Bolt's module loader. Override it so Bolt sees each
+# directory as a distinct entry.
+module BoltSpec
+  module BoltContext
+    def modulepath
+      RSpec.configuration.module_path.split(File::PATH_SEPARATOR)
+    end
+  end
 end

--- a/modules/aggregate/spec/spec_helper.rb
+++ b/modules/aggregate/spec/spec_helper.rb
@@ -1,21 +1,9 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'rspec-puppet'
+require_relative '../../../bolt-modules/shared_spec_helper'
 require 'bolt_spec/plans'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path('fixtures/modules', __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!
 
 # BoltSpec::BoltContext#modulepath wraps RSpec.configuration.module_path in
 # a single-element array, which leaves colon-separated paths joined and

--- a/modules/canary/.fixtures.yml
+++ b/modules/canary/.fixtures.yml
@@ -1,5 +1,0 @@
----
-fixtures:
-  symlinks:
-    canary: "#{source_dir}"
-    boltlib: "#{File.absolute_path(File.join(source_dir, '..', '..', 'bolt-modules', 'boltlib'))}"

--- a/modules/canary/spec/spec_helper.rb
+++ b/modules/canary/spec/spec_helper.rb
@@ -1,10 +1,30 @@
 # frozen_string_literal: true
 
 require 'puppet_pal'
+require 'rspec-puppet'
+require 'bolt_spec/plans'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path('fixtures/modules', __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
+end
+
+# BoltSpec::BoltContext#modulepath wraps RSpec.configuration.module_path in
+# a single-element array, which leaves colon-separated paths joined and
+# unsplittable by Bolt's module loader. Override it so Bolt sees each
+# directory as a distinct entry.
+module BoltSpec
+  module BoltContext
+    def modulepath
+      RSpec.configuration.module_path.split(File::PATH_SEPARATOR)
+    end
+  end
 end

--- a/modules/canary/spec/spec_helper.rb
+++ b/modules/canary/spec/spec_helper.rb
@@ -1,21 +1,9 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'rspec-puppet'
+require_relative '../../../bolt-modules/shared_spec_helper'
 require 'bolt_spec/plans'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path('fixtures/modules', __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!
 
 # BoltSpec::BoltContext#modulepath wraps RSpec.configuration.module_path in
 # a single-element array, which leaves colon-separated paths joined and

--- a/modules/puppetdb_fact/spec/plans/init_spec.rb
+++ b/modules/puppetdb_fact/spec/plans/init_spec.rb
@@ -16,13 +16,13 @@ describe 'puppetdb_fact' do
   }
 
   it 'returns facts from PuppetDB' do
-    puppetdb_client.expects(:facts_for_node).with(facts.keys, nil).returns(facts)
+    expect(puppetdb_client).to receive(:facts_for_node).with(facts.keys, nil).and_return(facts)
     result = run_plan('puppetdb_fact', 'targets' => facts.keys)
     expect(result).to eq(Bolt::PlanResult.new(facts, 'success'))
   end
 
   it 'adds facts to Targets' do
-    puppetdb_client.expects(:facts_for_node).with(facts.keys, nil).returns(facts)
+    expect(puppetdb_client).to receive(:facts_for_node).with(facts.keys, nil).and_return(facts)
     run_plan('puppetdb_fact', 'targets' => facts.keys)
     facts.each do |k, v|
       expect(inventory.facts(Bolt::Target.new(k))).to eq(v)
@@ -30,7 +30,7 @@ describe 'puppetdb_fact' do
   end
 
   it 'returns an empty hash for an empty list' do
-    puppetdb_client.expects(:facts_for_node).with([], nil).returns({})
+    expect(puppetdb_client).to receive(:facts_for_node).with([], nil).and_return({})
     result = run_plan('puppetdb_fact', 'targets' => [])
     expect(result).to eq(Bolt::PlanResult.new({}, 'success'))
   end

--- a/modules/puppetdb_fact/spec/spec_helper.rb
+++ b/modules/puppetdb_fact/spec/spec_helper.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
 require 'puppet_pal'
+require 'rspec-puppet'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+
 RSpec.configure do |c|
-  c.mock_with :mocha
+  repo_root = File.expand_path('../../..', __dir__)
+  c.module_path = [
+    File.expand_path("fixtures/modules", __dir__),
+    File.join(repo_root, 'bolt-modules'),
+    File.join(repo_root, 'modules')
+  ].join(File::PATH_SEPARATOR)
 end

--- a/modules/puppetdb_fact/spec/spec_helper.rb
+++ b/modules/puppetdb_fact/spec/spec_helper.rb
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppet_pal'
-require 'rspec-puppet'
+require_relative '../../../bolt-modules/shared_spec_helper'
 
-# Ensure tasks are enabled when rspec-puppet sets up an environment
-# so we get task loaders.
-Puppet[:tasks] = true
-
-RSpec.configure do |c|
-  repo_root = File.expand_path('../../..', __dir__)
-  c.module_path = [
-    File.expand_path("fixtures/modules", __dir__),
-    File.join(repo_root, 'bolt-modules'),
-    File.join(repo_root, 'modules')
-  ].join(File::PATH_SEPARATOR)
-end
+configure_rspec_for_this_module!

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -141,28 +141,19 @@ begin
     desc "Run RSpec tests for Bolt's bundled content"
     task :modules do
       success = true
+      run_specs = lambda do |dir|
+        Dir.chdir(dir) do
+          sh 'rspec spec' do |ok, _|
+            success = false unless ok
+          end
+        end
+      end
       # Test core modules
-      Pathname.new("#{__dir__}/../bolt-modules").each_child do |mod|
-        Dir.chdir(mod) do
-          sh 'rake spec' do |ok, _|
-            success = false unless ok
-          end
-        end
-      end
-      # Test modules
-      %w[canary aggregate puppetdb_fact].each do |mod|
-        Dir.chdir("#{__dir__}/../modules/#{mod}") do
-          sh 'rake spec' do |ok, _|
-            success = false unless ok
-          end
-        end
-      end
+      Pathname.new("#{__dir__}/../bolt-modules").each_child(&run_specs)
+      # Test bundled content modules
+      Pathname.new("#{__dir__}/../modules").each_child(&run_specs)
       # Test BoltSpec
-      Dir.chdir("#{__dir__}/../bolt_spec_spec/") do
-        sh 'rake spec' do |ok, _|
-          success = false unless ok
-        end
-      end
+      run_specs.call("#{__dir__}/../bolt_spec_spec")
       raise "Module tests failed" unless success
     end
   end

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -151,6 +151,7 @@ begin
       each_module_dir = lambda do |base|
         Pathname.new(base).each_child do |child|
           next unless child.directory? && child.join('spec').directory?
+
           run_specs.call(child)
         end
       end

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -142,6 +142,7 @@ begin
     task :modules do
       success = true
       run_specs = lambda do |dir|
+        puts "\n=== Running specs for module '#{File.basename(dir)}' ==="
         Dir.chdir(dir) do
           sh 'rspec spec' do |ok, _|
             success = false unless ok

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -148,11 +148,14 @@ begin
           end
         end
       end
-      # Test core modules
-      Pathname.new("#{__dir__}/../bolt-modules").each_child(&run_specs)
-      # Test bundled content modules
-      Pathname.new("#{__dir__}/../modules").each_child(&run_specs)
-      # Test BoltSpec
+      each_module_dir = lambda do |base|
+        Pathname.new(base).each_child do |child|
+          next unless child.directory? && child.join('spec').directory?
+          run_specs.call(child)
+        end
+      end
+      each_module_dir.call("#{__dir__}/../bolt-modules")
+      each_module_dir.call("#{__dir__}/../modules")
       run_specs.call("#{__dir__}/../bolt_spec_spec")
       raise "Module tests failed" unless success
     end


### PR DESCRIPTION
This PR has both a rspec-only migration, and then one after where we use voxpupuli-test, which is probably the better option. Left both for consideration.

**First commit**:
The ci:modules rake task had silently been a no-op since commit 722532c5d removed the per-module Rakefiles in July 2025. It iterated each bundled module directory and shelled out to rake spec, which walked up to the top level Rakefile and errored out because no spec task was defined there.

Rewrite ci:modules to invoke rspec directly, update each module spec_helper to configure rspec-puppet with a proper module_path, migrate ~420 mocha-style call sites to rspec-mocks, refactor around(:each) + Puppet.override wrappers into before(:each)/after(:each) push_context pairs (rspec-mocks rejects double setup from around hooks running before example.run), and drop mocha from the Gemfile.

Fix test bugs that were silently broken while ci:modules was a no-op: rename pcp:// test targets to remote:// (pcp transport was removed from openvox), delete two tests that exercised a dead pcp-only code path in run_task / run_task_with, correct inventory.get_target typos to get_targets, fix wait_until_available argument expectation, and require bolt/target in the prompt spec_helper so Puppet type signatures load.

**Second commit**:
Consolidate bundled module spec_helpers via shared helper

Replace 13 near-identical module spec_helper.rb files with three-line
wrappers that delegate to bolt-modules/shared_spec_helper.rb. The shared
helper configures rspec-puppet's module_path to point at bolt-modules/
and modules/ directly, avoiding fixture symlinks. Canary and aggregate
retain their BoltSpec::BoltContext#modulepath override since Bolt's task
loader does not split a colon-separated RSpec.configuration.module_path
string into individual entries.

Adopt voxpupuli-test in the Gemfile to bundle rspec-puppet and friends
via a single convention-aligned gem. Drop rspec-puppet and
puppet_fixtures as standalone direct deps.
Delete the stale .fixtures.yml files in canary and aggregate. Their old
symlink-based fixture setup is no longer needed now that the shared
helper puts bolt-modules/ on the modulepath directly, and the stale
spec/fixtures/modules/boltlib symlinks were in fact causing rspec's
default spec discovery to descend into them and re-run boltlib's specs
from the wrong module's context.

Apply the corresponding rubocop autocorrections to spec files under
bolt-modules that rubocop-rspec 3.9 (pulled in transitively by
voxpupuli-test) now flags.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
