### PR TITLE
package build: replace `build`-> `vanagon build`

### DIFF
--- a/rakelib/build.rake
+++ b/rakelib/build.rake
@@ -21,7 +21,7 @@ namespace :vox do
     end
 
     engine = platform =~ /^(macos|windows)-/ ? 'local' : 'docker'
-    cmd = "bundle exec build #{project} #{platform} --engine #{engine}"
+    cmd = "bundle exec vanagon build #{project} #{platform} --engine #{engine}"
 
     Dir.chdir('packaging') do
       run_command(cmd, silent: false, print_command: true, report_status: true)


### PR DESCRIPTION
the `build` command is deprecated:

```
$ bundle exec build
build: Warning: use of stand alone 'build' command is deprecated and may be removed.
     Use: 'vanagon build' instead.
Usage:
build [options] <project-name> <platforms> [<targets>]
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
