### PR TITLE
Fix concurrency test bug and install modules before unit tests

### DIFF
--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -10,11 +10,16 @@ begin
   end
 
   namespace :tests do
+    desc 'Install Puppetfile modules required by the spec suite'
+    task :install_modules do
+      sh 'bundle exec r10k puppetfile install'
+    end
+
     desc "Run all RSpec tests"
     RSpec::Core::RakeTask.new(:spec)
 
     desc "Run RSpec tests that do not require VM fixtures or a particular shell"
-    RSpec::Core::RakeTask.new(:unit) do |t|
+    RSpec::Core::RakeTask.new(unit: :install_modules) do |t|
       t.pattern = "spec/unit/**/*_spec.rb"
     end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -25,7 +25,18 @@ describe Bolt::Config do
   describe "defaults" do
     let(:config) { Bolt::Config.new(project, {}) }
 
-    it 'sets concurrency to 100' do
+    it 'sets concurrency to SC_OPEN_MAX / 7 when the ulimit is low', unless: Bolt::Util.windows? do
+      allow(Etc).to receive(:sysconf).with(Etc::SC_OPEN_MAX).and_return(49)
+      expect(config.concurrency).to eq(7)
+    end
+
+    it 'caps concurrency at 100 when the ulimit is not low', unless: Bolt::Util.windows? do
+      allow(Etc).to receive(:sysconf).with(Etc::SC_OPEN_MAX).and_return(800)
+      expect(config.concurrency).to eq(100)
+    end
+
+    it 'defaults concurrency to 100 on Windows' do
+      allow(Bolt::Util).to receive(:windows?).and_return(true)
       expect(config.concurrency).to eq(100)
     end
 


### PR DESCRIPTION
### Short description
#### Run install_modules before tests:unit
These tests require running 'bundle exec r10k puppetfile install' before running, so this ensures it happens before running tests. It's idempotent and only takes about a second when it's already installed, so we just run it every time.
#### Fix concurrency test
The default concurrency value is based on what Etc::SC_OPEN_MAX (ulimit) is set to, either divided by 7 or capped at 100. When running unit tests in an environment where this value is less than 700, it results in a number less than the expected 100. Instead, the test is now two tests where the call is stubbed and we verify both the divide by 7 and the 100 cap behavior.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
