### PR TITLE
Fix `bolt guide` crash when using rainbow formatter

### DIFF
--- a/lib/bolt/application.rb
+++ b/lib/bolt/application.rb
@@ -148,10 +148,8 @@ module Bolt
 
     # Show available guides.
     #
-    # @param guides [Hash] A map of topics to paths to guides.
-    # @param outputter [Bolt::Outputter] An outputter instance.
-    # @return [Boolean]
-    #
+    # @return [Hash] A map of topics of guides
+    #   Currently, the map is structured as `:topics => [Array] of guide names`
     def list_guides
       { topics: load_guides.keys }
     end

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -486,7 +486,7 @@ module Bolt
       #
       # @param topics [Array] The available topics.
       #
-      def print_topics(topics:, **_kwargs)
+      def print_topics(topics:)
         info = +"#{colorize(:cyan, 'Topics')}\n"
         info << indent(2, topics.join("\n"))
         info << "\n\n#{colorize(:cyan, 'Additional information')}\n"

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -122,8 +122,8 @@ module Bolt
       #
       # @param topics [Array] The available topics.
       #
-      def print_topics(**kwargs)
-        print_table(kwargs)
+      def print_topics(topics:)
+        print_table({ topics: topics })
       end
 
       # Print the guide for the specified topic.

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -104,7 +104,11 @@ module Bolt
         @stream.puts colorize(:rainbow, guide)
       end
 
-      def print_topics(topics)
+      # Print available guide topics.
+      #
+      # @param topics [Array] The available topics.
+      #
+      def print_topics(topics:, **_kwargs)
         content  = String.new("Available topics are:\n")
         content += topics.join("\n")
         content += "\n\nUse `bolt guide <topic>` to view a specific guide."

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -108,7 +108,7 @@ module Bolt
       #
       # @param topics [Array] The available topics.
       #
-      def print_topics(topics:, **_kwargs)
+      def print_topics(topics:)
         content  = String.new("Available topics are:\n")
         content += topics.join("\n")
         content += "\n\nUse `bolt guide <topic>` to view a specific guide."

--- a/spec/unit/outputter/rainbow_spec.rb
+++ b/spec/unit/outputter/rainbow_spec.rb
@@ -65,7 +65,7 @@ describe "Bolt::Outputter::Rainbow" do
     CONTENT
 
     expect(outputter).to receive(:colorize).with(:rainbow, content)
-    outputter.print_topics(%w[foo bar])
+    outputter.print_topics(topics: %w[foo bar])
   end
 
   it "colorizes a message" do


### PR DESCRIPTION
### Short description
Fixes #229

Follows the example of the `human` outputter.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
