### PR TITLE
Add main vs. 8.x toggle to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,13 @@ on:
         required: false
         type: boolean
         default: false
+      branch:
+        description: 'The release branch to build from.'
+        type: choice
+        options:
+          - main
+          - '8.x'
+        default: 'main'
 
 jobs:
   build:
@@ -45,6 +52,7 @@ jobs:
       vanagon_branch: ${{ inputs.vanagon_branch }}
       upload_to_s3: ${{ inputs.upload_to_s3 }}
       working_directory: 'packaging'
+      branch: ${{ inputs.branch }}
     secrets: inherit
   build_dev:
     if: ${{ github.event.inputs.use_dev == 'true' }}
@@ -56,4 +64,5 @@ jobs:
       vanagon_branch: ${{ inputs.vanagon_branch }}
       upload_to_s3: ${{ inputs.upload_to_s3 }}
       working_directory: 'packaging'
+      branch: ${{ inputs.branch }}
     secrets: inherit


### PR DESCRIPTION
### Short description

This patchset ports OpenVoxProject/openvox#425 over to `puppet-runtime`. The change adds a drop-down that allows selection of which platform set from `platforms.json` in OpenVoxProject/shared-actions should be used by the build.

This enables building the `openbolt` package against the 8.x platform list instead of the OpenVox 9 list.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
