### PR TITLE
Fix broken cross-links in generated reference pages

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -11,7 +11,7 @@
 #   The target's facts. This function does not look up facts for a target and
 #   only returns the facts specified in an `inventory.yaml` file or set on a
 #   target during a plan run. To retrieve facts for a target and set them in
-#   inventory, run the [facts](writing_plans.md#collect-facts-from-targets)
+#   inventory, run the [facts](writing_plans.md#collect-facts-from-the-targets)
 #   plan or [puppetdb_fact](writing_plans.md#collect-facts-from-puppetdb)
 #   plan.
 # @param features
@@ -20,7 +20,7 @@
 #   The target's human-readable name, or its URI if a name was not given.
 # @param plugin_hooks
 #   The target's `plugin_hooks` [configuration
-#   options](bolt_inventory_reference.md#plugin-hooks-1).
+#   options](bolt_inventory_reference.md#plugin_hooks-1).
 # @param resources
 #   The target's resources. This function does not look up resources for a
 #   target and only returns resources set on a target during a plan run.

--- a/bolt-modules/boltlib/lib/puppet/functions/facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/facts.rb
@@ -7,7 +7,7 @@ require 'bolt/error'
 # Using the `facts` function does not automatically collect facts for a target,
 # and will only return facts that are currently set in the inventory. To collect
 # facts from a target and set them in the inventory, run the
-# [facts](writing_plans.md#collect-facts-from-targets) plan or
+# [facts](writing_plans.md#collect-facts-from-the-targets) plan or
 # [puppetdb_fact](writing_plans.md#collect-facts-from-puppetdb) plan.
 Puppet::Functions.create_function(:facts) do
   # @param target A target.

--- a/documentation/templates/bolt_types_reference.md.erb
+++ b/documentation/templates/bolt_types_reference.md.erb
@@ -94,5 +94,5 @@ Plans can return just about any Puppet type, so the `PlanResult` can be any of t
   Hash.
 
 📖  **Related information**
-- [`run_plan()` plan function](plan_functions.html#run-plan)
+- [`run_plan()` plan function](plan_functions.html#run_plan)
 - [`parallelize()` plan function](plan_functions.html#parallelize)

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -436,10 +436,10 @@ module Bolt
           _example: ["myproject", "myproject::foo", "myproject::bar", "myproject::deploy::*"]
         },
         "plugin-hooks" => {
-          description: "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. " \
+          description: "A map of [plugin hooks](writing_plugins.md#plugin-hooks) and which plugins a hook should use. " \
                        "The only configurable plugin hook is `puppet_library`, which can use two possible plugins: " \
                        "[`openvox_bootstrap`](https://github.com/voxpupuli/puppet-openvox_bootstrap#openvox_boostrapinstall) " \
-                       "and [`task`](using_plugins.md#task).",
+                       "and [`task`](supported_plugins.md#task).",
           type: Hash,
           _plugin: true,
           _example: { "puppet_library" => { "plugin" => "openvox_bootstrap", "version" => "1.2.0",

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -297,7 +297,7 @@ begin
         "desc"       => "Applies a block of manifest code to the targets.\n\nApplying manifest " \
                         "code requires facts to compile a catalog. Targets must also have " \
                         "the Puppet agent package installed to apply manifest code. To prep " \
-                        "targets for an apply, call the [apply_prep](#apply-prep) function before " \
+                        "targets for an apply, call the [apply_prep](#apply_prep) function before " \
                         "the apply function.\n\nTo learn more about applying manifest code from a plan, " \
                         "see [Applying manifest blocks from a Puppet " \
                         "plan](applying_manifest_blocks.html#applying-manifest-blocks-from-a-puppet-plan).\n\n" \

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -238,7 +238,7 @@
       }
     },
     "plugin-hooks": {
-      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`openvox_bootstrap`](https://github.com/voxpupuli/puppet-openvox_bootstrap#openvox_boostrapinstall) and [`task`](using_plugins.md#task).",
+      "description": "A map of [plugin hooks](writing_plugins.md#plugin-hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`openvox_bootstrap`](https://github.com/voxpupuli/puppet-openvox_bootstrap#openvox_boostrapinstall) and [`task`](supported_plugins.md#task).",
       "oneOf": [
         {
           "type": "object"

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -361,7 +361,7 @@
       }
     },
     "plugin-hooks": {
-      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`openvox_bootstrap`](https://github.com/voxpupuli/puppet-openvox_bootstrap#openvox_boostrapinstall) and [`task`](using_plugins.md#task).",
+      "description": "A map of [plugin hooks](writing_plugins.md#plugin-hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`openvox_bootstrap`](https://github.com/voxpupuli/puppet-openvox_bootstrap#openvox_boostrapinstall) and [`task`](supported_plugins.md#task).",
       "oneOf": [
         {
           "type": "object"


### PR DESCRIPTION
## What

Fixes the broken internal cross-links emitted by the generated reference pages (#249). These 404 when published to docs.openvoxproject.org/openbolt/latest and can't be fixed downstream because the pages are generated from this repo. All fixed at the source that feeds the generators:

| Broken link | Fix | Source |
| --- | --- | --- |
| `plan_functions#run-plan` | `#run_plan` | `documentation/templates/bolt_types_reference.md.erb` |
| `[apply_prep](#apply-prep)` (self-link) | `#apply_prep` | `rakelib/docs.rake` (`apply` func desc) |
| `bolt_inventory_reference#plugin-hooks-1` | `#plugin_hooks-1` | `bolt-modules/.../datatypes/target.rb` |
| `writing_plans#collect-facts-from-targets` | `#collect-facts-from-the-targets` | `target.rb` + `bolt-modules/.../functions/facts.rb` |
| `writing_plugins#hooks` | `#plugin-hooks` | `lib/bolt/config/options.rb` |
| `using_plugins#task` | `supported_plugins#task` | `lib/bolt/config/options.rb` |

The `bolt-defaults` / `bolt-project` schema JSON are regenerated from the same OPTIONS hash, so they're updated to match. (The `task` plugin is documented on `supported_plugins`, not `using_plugins`.)

## On the "removed/relocated sections" in the issue

While verifying, the failures into `writing_plans` / `writing_tasks` turned out **not** to be removed sections — those sections still exist. The published pages stopped emitting heading IDs partway down because kramdown flipped into raw mode (a `<TYPE> <PARAMETER_NAME>` code span split across a line break, and ` ```shell script ` fences with a space in the info string). Those authored pages now live only in openvox-docs, so that render-bug fix is the companion PR **OpenVoxProject/openvox-docs#289** — not this repo.

## Verification

Regenerated the openbolt references with these changes into a full openvox-docs build and ran html-proofer scoped to `_site/openbolt/latest`; the generated-page cross-links above all resolve (collection reaches 0 broken links together with openvox-docs#289).

Fixes #249
