### PR TITLE
Add `puppetfile` option to bolt-project.yaml

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -484,6 +484,14 @@ module Bolt
           },
           _plugin: true
         },
+        "puppetfile" => {
+          description: "The path to the project's Puppetfile, used by `bolt module install` and " \
+                       "related commands. Relative paths are resolved from the project directory; " \
+                       "absolute paths are used as-is. Defaults to `Puppetfile` in the project directory.",
+          type: String,
+          _example: "control-repo/Puppetfile",
+          _plugin: true
+        },
         "rerunfile" => {
           description: "The path to the project's rerun file. The rerun file is used to store information " \
                        "about targets from the most recent run. Expands relative to the project directory.",
@@ -668,6 +676,7 @@ module Bolt
         policies
         puppetdb
         puppetdb-instances
+        puppetfile
         rerunfile
         save-rerun
         spinner

--- a/lib/bolt/module_installer/puppetfile.rb
+++ b/lib/bolt/module_installer/puppetfile.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 require_relative '../../bolt/error'
 require_relative 'puppetfile/forge_module'
 require_relative 'puppetfile/git_module'
@@ -69,6 +71,7 @@ module Bolt
       # modules.
       #
       def write(path, moduledir = nil)
+        FileUtils.mkdir_p(File.dirname(path))
         File.open(path, 'w') do |file|
           if moduledir
             file.puts "# This Puppetfile is managed by Bolt. Do not edit."

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -132,6 +132,10 @@ module Bolt
         @rerunfile = File.expand_path(@data['rerunfile'], @path)
       end
 
+      if @data['puppetfile']
+        @puppetfile = Pathname.new(File.expand_path(@data['puppetfile'], @path))
+      end
+
       validate if project_file?
     end
 

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -132,7 +132,7 @@ module Bolt
         @rerunfile = File.expand_path(@data['rerunfile'], @path)
       end
 
-      if @data['puppetfile']
+      if @data['puppetfile'].is_a?(String)
         @puppetfile = Pathname.new(File.expand_path(@data['puppetfile'], @path))
       end
 

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -133,7 +133,12 @@ module Bolt
       end
 
       if @data['puppetfile'].is_a?(String)
-        @puppetfile = Pathname.new(File.expand_path(@data['puppetfile'], @path))
+        expanded = File.expand_path(@data['puppetfile'], @path)
+        unless expanded.start_with?(@path.to_s + '/')
+          raise Bolt::ValidationError,
+                "Option 'puppetfile' must be a relative path within the project directory."
+        end
+        @puppetfile = Pathname.new(expanded)
       end
 
       validate if project_file?

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -67,6 +67,9 @@
     "puppetdb-instances": {
       "$ref": "#/definitions/puppetdb-instances"
     },
+    "puppetfile": {
+      "$ref": "#/definitions/puppetfile"
+    },
     "rerunfile": {
       "$ref": "#/definitions/rerunfile"
     },
@@ -599,6 +602,17 @@
               }
             ]
           }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "puppetfile": {
+      "description": "The path to the project's Puppetfile, used by `bolt module install` and related commands. Relative paths are resolved from the project directory; absolute paths are used as-is. Defaults to `Puppetfile` in the project directory.",
+      "oneOf": [
+        {
+          "type": "string"
         },
         {
           "$ref": "#/definitions/_plugin"

--- a/spec/integration/module_installer/module_installer_spec.rb
+++ b/spec/integration/module_installer/module_installer_spec.rb
@@ -57,6 +57,22 @@ describe 'installing modules' do
     end
   end
 
+  context 'with a puppetfile override in bolt-project.yaml' do
+    let(:project_config) { { 'puppetfile' => 'custom/Puppetfile' } }
+
+    it 'writes the puppetfile at the override path and not the default' do
+      output = run_cli_json(%w[module add puppetlabs-yaml], project: project)
+      expect(output['puppetfile']).to eq((project.path + 'custom' + 'Puppetfile').to_s)
+      expect(output['success']).to be
+
+      expect(File.exist?(project.path + 'custom' + 'Puppetfile')).to be true
+      expect(File.exist?(project.path + 'Puppetfile')).to be false
+
+      puppetfile_content = File.read(project.path + 'custom' + 'Puppetfile')
+      expect(puppetfile_content.lines).to include(%r{mod 'puppetlabs/yaml'})
+    end
+  end
+
   context 'with install configuration' do
     let(:base_config) do
       {

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -81,6 +81,44 @@ describe Bolt::Project do
       end
     end
 
+    describe "#puppetfile" do
+      context "without a puppetfile override" do
+        let(:project_config) { {} }
+
+        it "defaults to <project>/Puppetfile" do
+          expect(project.puppetfile).to be_a(Pathname)
+          expect(project.puppetfile).to eq(project.path + 'Puppetfile')
+        end
+      end
+
+      context "with a relative puppetfile override" do
+        let(:project_config) { { 'puppetfile' => 'custom/Puppetfile.dev' } }
+
+        it "resolves the path relative to the project directory" do
+          expect(project.puppetfile).to be_a(Pathname)
+          expect(project.puppetfile).to eq(project.path + 'custom' + 'Puppetfile.dev')
+        end
+      end
+
+      context "with an absolute puppetfile override" do
+        let(:project_config) { { 'puppetfile' => '/tmp/shared/Puppetfile' } }
+
+        it "uses the absolute path verbatim" do
+          expect(project.puppetfile).to be_a(Pathname)
+          expect(project.puppetfile).to eq(Pathname.new('/tmp/shared/Puppetfile'))
+        end
+      end
+
+      context "with a non-string puppetfile value" do
+        let(:project_config) { { 'puppetfile' => 42 } }
+
+        it "fails project schema validation" do
+          expect { Bolt::Project.create_project(@project_path) }
+            .to raise_error(Bolt::ValidationError, /puppetfile/)
+        end
+      end
+    end
+
     describe "with namespaced project names" do
       let(:project_config) { { 'name' => 'puppetlabs-foo' } }
 

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -101,11 +101,14 @@ describe Bolt::Project do
       end
 
       context "with an absolute puppetfile override" do
-        let(:project_config) { { 'puppetfile' => '/tmp/shared/Puppetfile' } }
+        # File.expand_path on Windows prepends the cwd's drive letter to a
+        # Unix-style absolute, so feed the same expansion through both sides.
+        let(:absolute_path)  { File.expand_path('/tmp/shared/Puppetfile') }
+        let(:project_config) { { 'puppetfile' => absolute_path } }
 
         it "uses the absolute path verbatim" do
           expect(project.puppetfile).to be_a(Pathname)
-          expect(project.puppetfile).to eq(Pathname.new('/tmp/shared/Puppetfile'))
+          expect(project.puppetfile).to eq(Pathname.new(absolute_path))
         end
       end
 

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -100,15 +100,19 @@ describe Bolt::Project do
         end
       end
 
-      context "with an absolute puppetfile override" do
-        # File.expand_path on Windows prepends the cwd's drive letter to a
-        # Unix-style absolute, so feed the same expansion through both sides.
-        let(:absolute_path)  { File.expand_path('/tmp/shared/Puppetfile') }
-        let(:project_config) { { 'puppetfile' => absolute_path } }
+      context "with an absolute puppetfile path" do
+        let(:project_config) { { 'puppetfile' => File.expand_path('/tmp/shared/Puppetfile') } }
 
-        it "uses the absolute path verbatim" do
-          expect(project.puppetfile).to be_a(Pathname)
-          expect(project.puppetfile).to eq(Pathname.new(absolute_path))
+        it "raises a validation error" do
+          expect { project }.to raise_error(Bolt::ValidationError, /must be a relative path within the project directory/)
+        end
+      end
+
+      context "with a puppetfile path that escapes the project directory" do
+        let(:project_config) { { 'puppetfile' => '../outside/Puppetfile' } }
+
+        it "raises a validation error" do
+          expect { project }.to raise_error(Bolt::ValidationError, /must be a relative path within the project directory/)
         end
       end
 


### PR DESCRIPTION
This patch adds support and tests for a `puppetfile` option in `bolt-project.yaml` to specify an alternate Puppetfile name/location from the (presently unchangeable) `<project dir>/Puppetfile` generated by `bolt module install` and edited by `bolt module add`.  This will enable openbolt projects in control repositories to define their requirements separately from the Puppet-managed infrastructure.

Assisted-by: Claude Opus 4.7, on a tight leash
Fixes #262

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [X] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code -- _(N/A: actual code is basically two lines and an if)_
- [X] added or modified ~~regression~~ integration test(s)
- [X] added or modified unit test(s)
