### PR TITLE
Fix spurious test failure caused by line number

### DIFF
--- a/spec/integration/cli/cli_spec.rb
+++ b/spec/integration/cli/cli_spec.rb
@@ -429,7 +429,7 @@ describe 'commands' do
           ['sample::params', 'Task with parameters']
         )
 
-        expect(@log_output.readlines).to include(/WARN  Puppet : expected object key, got: '}' at line 24 column 3/)
+        expect(@log_output.readlines).to include(/WARN  Puppet : expected object key, got: '}' at line \d\d column 3/)
       end
     end
   end


### PR DESCRIPTION
This 2-character patch fixes a spurious test failure caused by a an over-fitted error message, causing failures like:

```
Failure/Error: expect(@log_output.readlines).to include(/WARN  Puppet : expected object key, got: '}' at line 24 column 3/)
```

When the test was modified last year, it included the line number in the error, pinning it to line 24.  However, there are now [various PRs](https://github.com/OpenVoxProject/openbolt/actions/runs/28241966800/job/83671097601?pr=261#step:6:14) failing tests because―although expected error occurs―error line number is 25.  

This patch changes the expectation of `24` to `\d\d`, because the line number is brittle but the the failure message and column are not.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [X] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified ~~regression~~ integration test(s)
- [ ] added or modified unit test(s)
