### PR TITLE
Pin bindata gem dependency to < 3.0

### DIFF
--- a/openbolt.gemspec
+++ b/openbolt.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", '~> 2.5'
   spec.add_dependency "aws-sdk-ec2", '~> 1'
+  spec.add_dependency "bindata", "< 3.0"
   spec.add_dependency "CFPropertyList", ">= 2.2"
   spec.add_dependency "choria-mcorpc-support", "~> 2.26"
   spec.add_dependency "concurrent-ruby", "~> 1.0"


### PR DESCRIPTION
### Short description

The new 3.0 release of bindata has resulted in failing test suites as `ruby_smb` 1.0 is no longer compatible with it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
