### PR TITLE
Replace dead pup.pt short links with docs.openvoxproject.org URLs

### DIFF
--- a/guides/debugging.yaml
+++ b/guides/debugging.yaml
@@ -24,4 +24,4 @@ guide: |
     specific issues.
 
 documentation:
-  - https://pup.pt/bolt-troubleshooting
+  - https://docs.openvoxproject.org/openbolt/latest/troubleshooting.html

--- a/guides/inventory.yaml
+++ b/guides/inventory.yaml
@@ -19,5 +19,5 @@ guide: |
     is different than expected.
 
 documentation:
-  - https://pup.pt/bolt-inventory
-  - https://pup.pt/bolt-inventory-reference
+  - https://docs.openvoxproject.org/openbolt/latest/inventory_files.html
+  - https://docs.openvoxproject.org/openbolt/latest/bolt_inventory_reference.html

--- a/guides/links.yaml
+++ b/guides/links.yaml
@@ -1,12 +1,21 @@
 ---
 topic: links
 guide: |
-    Bolt documentation          https://bolt.guide
-    Ask a question in #bolt     https://slack.puppet.com/
-    Contribute at               https://github.com/puppetlabs/bolt/
-    Getting Started Guide       https://pup.pt/bolt-getting-started
-    Reference Documentation     https://pup.pt/bolt-reference
-    Troubleshooting Bolt        https://pup.pt/bolt-troubleshooting
-    Bolt Developer Updates      https://pup.pt/bolt-dev-updates
-    Bolt Changelog              https://pup.pt/bolt-changelog
-    Bolt Examples               https://pup.pt/bolt-examples
+    OpenBolt documentation
+      https://docs.openvoxproject.org/openbolt/latest/
+    Getting Started Guide
+      https://docs.openvoxproject.org/openbolt/latest/getting_started_with_bolt.html
+    Configuration Reference
+      https://docs.openvoxproject.org/openbolt/latest/configuring_bolt.html
+    Troubleshooting OpenBolt
+      https://docs.openvoxproject.org/openbolt/latest/troubleshooting.html
+    OpenBolt Developer Updates
+      https://docs.openvoxproject.org/openbolt/latest/developer_updates.html
+    OpenBolt Release Notes
+      https://docs.openvoxproject.org/openbolt/latest/release_notes.html
+    OpenBolt Examples
+      https://docs.openvoxproject.org/openbolt/latest/bolt_examples.html
+    Ask a question in #sig-openbolt
+      https://voxpupuli.org/connect/
+    Contribute at
+      https://github.com/OpenVoxProject/openbolt

--- a/guides/logging.yaml
+++ b/guides/logging.yaml
@@ -14,4 +14,4 @@ guide: |
     To learn more about projects, see the 'project' guide.
 
 documentation:
-  - https://pup.pt/bolt-logging
+  - https://docs.openvoxproject.org/openbolt/latest/logs.html

--- a/guides/module.yaml
+++ b/guides/module.yaml
@@ -15,4 +15,4 @@ guide: |
     To learn how modules are loaded by Bolt, see the 'modulepath' guide.
 
 documentation:
-  - https://pup.pt/bolt-modules
+  - https://docs.openvoxproject.org/openbolt/latest/modules.html

--- a/guides/modulepath.yaml
+++ b/guides/modulepath.yaml
@@ -21,4 +21,4 @@ guide: |
     To learn more about modules, see the 'module' guide.
 
 documentation:
-  - https://pup.pt/bolt-project-reference#modulepath
+  - https://docs.openvoxproject.org/openbolt/latest/bolt_project_reference.html#modulepath

--- a/guides/project.yaml
+++ b/guides/project.yaml
@@ -17,5 +17,5 @@ guide: |
     of a project.
 
 documentation:
-  - https://pup.pt/bolt-projects
-  - https://pup.pt/bolt-project-reference
+  - https://docs.openvoxproject.org/openbolt/latest/projects.html
+  - https://docs.openvoxproject.org/openbolt/latest/bolt_project_reference.html

--- a/guides/targets.yaml
+++ b/guides/targets.yaml
@@ -25,4 +25,4 @@ guide: |
     see 'bolt guide inventory'.
 
 documentation:
-  - https://pup.pt/bolt-commands
+  - https://docs.openvoxproject.org/openbolt/latest/running_bolt_commands.html

--- a/guides/transports.yaml
+++ b/guides/transports.yaml
@@ -4,7 +4,8 @@ guide: |
     Bolt uses transports (also known as protocols) to establish a connection
     with a target in order to run actions on the target. The default transport is
     SSH, and you can see available transports along with their configuration
-    options and defaults at http://pup.pt/bolt-reference.
+    options and defaults at
+    https://docs.openvoxproject.org/openbolt/latest/bolt_transports_reference.html.
 
     You can specify a transport for a target by prepending '<transport>://' to
     the target's URI. For example, to connect to a target with hostname
@@ -18,5 +19,5 @@ guide: |
     information about the Bolt inventory, run 'bolt guide inventory'.
 
 documentation:
-  - https://pup.pt/bolt-commands#specify-a-transport
-  - http://pup.pt/bolt-inventory#transport-configuration
+  - https://docs.openvoxproject.org/openbolt/latest/running_bolt_commands.html#specify-a-transport
+  - https://docs.openvoxproject.org/openbolt/latest/inventory_files.html#transport-configuration

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -82,16 +82,8 @@ module Bolt
       if File.exist?(filename)
         Bolt::Util.read_optional_yaml_hash(filename, 'analytics')
       else
-        # Remove || true if we fix this for Vox analytics
-        unless ENV['BOLT_DISABLE_ANALYTICS'] || true
-          msg = <<~ANALYTICS
-            Bolt collects data about how you use it. You can opt out of providing this data.
-            To learn how to disable data collection, or see what data Bolt collects and why,
-            see http://pup.pt/bolt-analytics
-          ANALYTICS
-          Bolt::Logger.warn_once('analytics_opt_out', msg)
-        end
-
+        # Analytics are disabled in this fork, so there is nothing to opt out of.
+        # If analytics are revived for Vox, restore an opt-out notice here.
         {}
       end
     end

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -245,7 +245,7 @@ module Bolt
           Apply Puppet manifest code on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-apply.
+          For documentation see https://docs.openvoxproject.org/openbolt/latest/applying_manifest_blocks.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt apply manifest.pp -t target
@@ -263,7 +263,7 @@ module Bolt
           Run a command on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://docs.openvoxproject.org/openbolt/latest/running_bolt_commands.html.
 
       #{colorize(:cyan, 'Actions')}
           run         Run a command on the specified targets.
@@ -281,7 +281,7 @@ module Bolt
           Run a command on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://docs.openvoxproject.org/openbolt/latest/running_bolt_commands.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt command run 'uptime' -t target1,target2
@@ -298,7 +298,7 @@ module Bolt
           Copy files and directories between the controller and targets.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://docs.openvoxproject.org/openbolt/latest/running_bolt_commands.html.
 
       #{colorize(:cyan, 'Actions')}
           download      Download a file or directory to the controller
@@ -322,7 +322,7 @@ module Bolt
           subdirectory of the project directory.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://docs.openvoxproject.org/openbolt/latest/running_bolt_commands.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt file download /etc/ssh_config ssh_config -t all
@@ -340,7 +340,7 @@ module Bolt
           Upload a local file or directory.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://docs.openvoxproject.org/openbolt/latest/running_bolt_commands.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt file upload /tmp/source /etc/profile.d/login.sh -t target1
@@ -445,7 +445,7 @@ module Bolt
           Look up a value with Hiera.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about using Hiera with Bolt at https://pup.pt/bolt-hiera.
+          Learn more about using Hiera with Bolt at https://docs.openvoxproject.org/openbolt/latest/hiera.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt lookup password --targets servers
@@ -551,7 +551,7 @@ module Bolt
           Convert, create, show, and run Bolt plans.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://docs.openvoxproject.org/openbolt/latest/plans.html.
 
       #{colorize(:cyan, 'Actions')}
           convert       Convert a YAML plan to a Bolt plan
@@ -576,7 +576,7 @@ module Bolt
           functionality. Note that the converted plan is not written to a file.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://docs.openvoxproject.org/openbolt/latest/plans.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt plan convert myproject::myplan
@@ -594,7 +594,7 @@ module Bolt
           Create a new plan in the current project.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://docs.openvoxproject.org/openbolt/latest/plans.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt plan new myproject::myplan
@@ -611,7 +611,7 @@ module Bolt
           Run a plan on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://docs.openvoxproject.org/openbolt/latest/plans.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt plan run canary --targets target1,target2 command=hostname
@@ -634,7 +634,7 @@ module Bolt
           the plan, including a list of available parameters.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://docs.openvoxproject.org/openbolt/latest/plans.html.
 
       #{colorize(:cyan, 'Examples')}
           Display a list of available plans
@@ -654,7 +654,7 @@ module Bolt
           Show available plugins.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plugins at https://pup.pt/bolt-plugins.
+          Learn more about Bolt plugins at https://docs.openvoxproject.org/openbolt/latest/using_plugins.html.
 
       #{colorize(:cyan, 'Actions')}
           show          Show available plugins
@@ -671,7 +671,7 @@ module Bolt
           Show available plugins.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plugins at https://pup.pt/bolt-plugins.
+          Learn more about Bolt plugins at https://docs.openvoxproject.org/openbolt/latest/using_plugins.html.
     HELP
 
     POLICY_HELP = <<~HELP
@@ -791,7 +791,7 @@ module Bolt
           Run a script on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about running scripts at https://pup.pt/bolt-commands.
+          Learn more about running scripts at https://docs.openvoxproject.org/openbolt/latest/running_bolt_commands.html.
 
       #{colorize(:cyan, 'Actions')}
           run         Run a script on the specified targets.
@@ -813,7 +813,7 @@ module Bolt
           be quoted.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about running scripts at https://pup.pt/bolt-commands.
+          Learn more about running scripts at https://docs.openvoxproject.org/openbolt/latest/running_bolt_commands.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt script run myscript.sh 'echo hello' --targets target1,target2
@@ -830,7 +830,7 @@ module Bolt
           Create encryption keys and encrypt and decrypt values.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about secrets plugins at http://pup.pt/bolt-plugins.
+          Learn more about secrets plugins at https://docs.openvoxproject.org/openbolt/latest/using_plugins.html.
 
       #{colorize(:cyan, 'Actions')}
           createkeys           Create new encryption keys
@@ -849,7 +849,7 @@ module Bolt
           Create new encryption keys.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about secrets plugins at http://pup.pt/bolt-plugins.
+          Learn more about secrets plugins at https://docs.openvoxproject.org/openbolt/latest/using_plugins.html.
     HELP
 
     SECRET_DECRYPT_HELP = <<~HELP
@@ -863,7 +863,7 @@ module Bolt
           Decrypt a value.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about secrets plugins at http://pup.pt/bolt-plugins.
+          Learn more about secrets plugins at https://docs.openvoxproject.org/openbolt/latest/using_plugins.html.
     HELP
 
     SECRET_ENCRYPT_HELP = <<~HELP
@@ -877,7 +877,7 @@ module Bolt
           Encrypt a value.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about secrets plugins at http://pup.pt/bolt-plugins.
+          Learn more about secrets plugins at https://docs.openvoxproject.org/openbolt/latest/using_plugins.html.
     HELP
 
     TASK_HELP = <<~HELP
@@ -891,7 +891,7 @@ module Bolt
           Show and run Bolt tasks.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt tasks at http://pup.pt/bolt-tasks.
+          Learn more about Bolt tasks at https://docs.openvoxproject.org/openbolt/latest/tasks.html.
 
       #{colorize(:cyan, 'Actions')}
           run          Run a Bolt task
@@ -912,7 +912,7 @@ module Bolt
           Parameters take the form parameter=value.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt tasks at http://pup.pt/bolt-tasks.
+          Learn more about Bolt tasks at https://docs.openvoxproject.org/openbolt/latest/tasks.html.
 
       #{colorize(:cyan, 'Examples')}
           bolt task run package --targets target1,target2 action=status name=bash
@@ -935,7 +935,7 @@ module Bolt
           the task, including a list of available parameters.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt tasks at http://pup.pt/bolt-tasks.
+          Learn more about Bolt tasks at https://docs.openvoxproject.org/openbolt/latest/tasks.html.
 
       #{colorize(:cyan, 'Examples')}
           Display a list of available tasks
@@ -1183,7 +1183,7 @@ module Bolt
         if File.exist?(path) || Pathname.new(path).absolute? ||
            !%w[scripts files].include?(path.split(File::SEPARATOR)[1])
           raise Bolt::CLIError, "The script must be a detailed Puppet file reference, " \
-            "for example 'mymodule/scripts/myscript.sh'. See http://pup.pt/bolt-scripts for " \
+            "for example 'mymodule/scripts/myscript.sh'. See https://docs.openvoxproject.org/openbolt/latest/bolt_running_scripts.html for " \
             "more information on detailed Puppet file references."
         end
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -359,7 +359,7 @@ module Bolt
           description: "A list of module dependencies for the project. Each dependency is a map of data specifying " \
                        "the module to install. To install the project's module dependencies, run the `bolt module " \
                        "install` command. For more information about specifying modules, see [the " \
-                       "documentation](https://pup.pt/bolt-module-specs).",
+                       "documentation](https://docs.openvoxproject.org/openbolt/latest/bolt_installing_modules.html#manually-specify-modules-in-a-bolt-project).",
           type: Array,
           items: {
             type: [Hash, String],

--- a/lib/bolt/inventory/options.rb
+++ b/lib/bolt/inventory/options.rb
@@ -84,7 +84,7 @@ module Bolt
         "plugin_hooks" => {
           description: "Configuration for the Puppet library plugin used to install the " \
                        "Puppet agent on the target. For more information, see " \
-                       "https://pup.pt/bolt-plugin-hooks",
+                       "https://docs.openvoxproject.org/openbolt/latest/writing_plugins.html",
           type: Hash,
           properties: {
             "puppet_library" => {

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -179,7 +179,7 @@ module Bolt
             'dotted_fact_name',
             "Target '#{safe_name}' includes dotted fact names: '#{dotted.join("', '")}'. Dotted fact " \
             "names are deprecated and Bolt does not automatically convert facts with dotted names to " \
-            "structured facts. For more information, see https://pup.pt/bolt-dotted-facts"
+            "structured facts. For more information, see https://docs.openvoxproject.org/openbolt/latest/developer_updates.html#deprecating-dotted-fact-names"
           )
         end
       end

--- a/lib/bolt/module_installer/puppetfile.rb
+++ b/lib/bolt/module_installer/puppetfile.rb
@@ -72,7 +72,7 @@ module Bolt
         File.open(path, 'w') do |file|
           if moduledir
             file.puts "# This Puppetfile is managed by Bolt. Do not edit."
-            file.puts "# For more information, see https://pup.pt/bolt-modules"
+            file.puts "# For more information, see https://docs.openvoxproject.org/openbolt/latest/modules.html"
             file.puts
             file.puts "# The following directive installs modules to the managed moduledir."
             file.puts "moduledir '#{moduledir.basename}'"

--- a/lib/bolt/module_installer/specs.rb
+++ b/lib/bolt/module_installer/specs.rb
@@ -57,7 +57,7 @@ module Bolt
           Invalid module specification:
           #{hash.to_yaml.lines.drop(1).join.chomp}
 
-          To read more about specifying modules, see https://pup.pt/bolt-module-specs
+          To read more about specifying modules, see https://docs.openvoxproject.org/openbolt/latest/bolt_installing_modules.html#manually-specify-modules-in-a-bolt-project
         MESSAGE
       end
 

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -645,7 +645,7 @@ module Bolt
         info << indent(2, "#{modulepath.join(File::PATH_SEPARATOR)}\n\n")
 
         info << colorize(:cyan, "Additional information\n")
-        info << indent(2, "For more information about using plugins see https://pup.pt/bolt-plugins")
+        info << indent(2, "For more information about using plugins see https://docs.openvoxproject.org/openbolt/latest/using_plugins.html")
 
         @stream.puts info.chomp
       end

--- a/lib/bolt/plan_creator.rb
+++ b/lib/bolt/plan_creator.rb
@@ -113,7 +113,7 @@ module Bolt
     private_class_method def self.yaml_plan(plan_name)
       <<~YAML
         # This is the structure of a simple plan. To learn more about writing
-        # YAML plans, see the documentation: http://pup.pt/bolt-yaml-plans
+        # YAML plans, see the documentation: https://docs.openvoxproject.org/openbolt/latest/writing_yaml_plans.html
 
         # The description sets the description of the plan that will appear
         # in 'bolt plan show' output.
@@ -146,7 +146,7 @@ module Bolt
     private_class_method def self.yaml_script_plan(script)
       <<~YAML
         # This is the structure of a simple plan. To learn more about writing
-        # YAML plans, see the documentation: http://pup.pt/bolt-yaml-plans
+        # YAML plans, see the documentation: https://docs.openvoxproject.org/openbolt/latest/writing_yaml_plans.html
 
         # The description sets the description of the plan that will appear
         # in 'bolt plan show' output.
@@ -177,7 +177,7 @@ module Bolt
     private_class_method def self.puppet_plan(plan_name)
       <<~PUPPET
         # This is the structure of a simple plan. To learn more about writing
-        # Puppet plans, see the documentation: http://pup.pt/bolt-puppet-plans
+        # Puppet plans, see the documentation: https://docs.openvoxproject.org/openbolt/latest/writing_plans.html
 
         # The summary sets the description of the plan that will appear
         # in 'bolt plan show' output. Bolt uses puppet-strings to parse the
@@ -202,7 +202,7 @@ module Bolt
     private_class_method def self.puppet_script_plan(plan_name, script)
       <<~PUPPET
         # This is the structure of a simple plan. To learn more about writing
-        # Puppet plans, see the documentation: http://pup.pt/bolt-puppet-plans
+        # Puppet plans, see the documentation: https://docs.openvoxproject.org/openbolt/latest/writing_plans.html
 
         # The summary sets the description of the plan that will appear
         # in 'bolt plan show' output. Bolt uses puppet-strings to parse the

--- a/lib/bolt/project_manager.rb
+++ b/lib/bolt/project_manager.rb
@@ -8,7 +8,7 @@ module Bolt
   class ProjectManager
     INVENTORY_TEMPLATE = <<~INVENTORY
       # This is an example inventory.yaml
-      # To read more about inventory files, see https://pup.pt/bolt-inventory
+      # To read more about inventory files, see https://docs.openvoxproject.org/openbolt/latest/inventory_files.html
       #
       # groups:
       #   - name: linux

--- a/lib/bolt/project_manager/inventory_migrator.rb
+++ b/lib/bolt/project_manager/inventory_migrator.rb
@@ -35,7 +35,7 @@ module Bolt
         rescue StandardError => e
           raise Bolt::FileError.new(
             "Unable to write to #{inventory_file}: #{e.message}. See " \
-            "http://pup.pt/bolt-inventory to manually update.",
+            "https://docs.openvoxproject.org/openbolt/latest/inventory_files.html to manually update.",
             inventory_file
           )
         end

--- a/lib/bolt/project_manager/module_migrator.rb
+++ b/lib/bolt/project_manager/module_migrator.rb
@@ -23,7 +23,7 @@ module Bolt
           @outputter.print_action_step(
             "Project has a non-default configured modulepath, unable to automatically " \
             "migrate project modules. To migrate project modules manually, see " \
-            "http://pup.pt/bolt-modules"
+            "https://docs.openvoxproject.org/openbolt/latest/modules.html"
           )
           true
         # Migrate modules from Puppetfile

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -484,7 +484,8 @@ module Bolt
           @logger.trace { "Command `#{command_str}` returned successfully" }
         when 126
           msg = "\n\nThis might be caused by the default tmpdir being mounted " \
-            "using 'noexec'. See http://pup.pt/task-failure for details and workarounds."
+            "using 'noexec'. See https://docs.openvoxproject.org/openbolt/latest/troubleshooting.html" \
+            "#my-task-fails-with-a-permission-denied-error-noexec-issue for details and workarounds."
           result_output.stderr        << msg
           result_output.merged_output << msg
           @logger.trace { "Command #{command_str} failed with exit code #{result_output.exit_code}" }

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -1854,7 +1854,7 @@
       ]
     },
     "plugin_hooks": {
-      "description": "Configuration for the Puppet library plugin used to install the Puppet agent on the target. For more information, see https://pup.pt/bolt-plugin-hooks",
+      "description": "Configuration for the Puppet library plugin used to install the Puppet agent on the target. For more information, see https://docs.openvoxproject.org/openbolt/latest/writing_plugins.html",
       "oneOf": [
         {
           "type": "object",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -278,7 +278,7 @@
       }
     },
     "modules": {
-      "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command. For more information about specifying modules, see [the documentation](https://pup.pt/bolt-module-specs).",
+      "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command. For more information about specifying modules, see [the documentation](https://docs.openvoxproject.org/openbolt/latest/bolt_installing_modules.html#manually-specify-modules-in-a-bolt-project).",
       "type": "array",
       "items": {
         "type": [


### PR DESCRIPTION
Fixes #277

The `pup.pt` redirector no longer resolves slugs. Every one of them bounces to a parked lander page:

```console
$ curl -sL https://pup.pt/bolt-commands
<!DOCTYPE html><html><head><script>window.onload=function(){window.location.href="/lander"}</script></head></html>
```

The hostname is also on the resale market, so whoever buys it inherits URLs that OpenBolt prints in CLI help text, JSON schemas, generated Puppetfile comments, and error messages.

This replaces all 59 actionable references with full `https://docs.openvoxproject.org/openbolt/latest/` URLs — the convention `README.md` and `CONTRIBUTING.md` already use. The 12 hits in `CHANGELOG.md` and `HISTORY.md` are left alone as historical release records.

| Location | Count |
| --- | --- |
| `lib/bolt/bolt_option_parser.rb` | 24 |
| `guides/*.yaml` | 18 |
| `lib/bolt/**` (other) | 15 |
| `schemas/*.json` | 2 |

Rather than a replacement short domain: the indirection is what failed here. A third-party redirector disappeared and took 59 links with it, silently, with no way for CI to notice. A new domain would add a renewal obligation and a redirect map to maintain, for the sake of URL length in help text.

## Notes for review

- **Schema JSON is generated**, not hand-edited. The two hits come from the `OPTIONS` hashes in `lib/bolt/config/options.rb` and `lib/bolt/inventory/options.rb`; `rake schemas:all` reproduces the committed output exactly.
- **`guides/links.yaml`** is what `bolt guide links` prints. Beyond its `pup.pt` entries it still advertised `bolt.guide`, `slack.puppet.com`, and `puppetlabs/bolt`, so those are updated to their OpenVox equivalents in the same pass. The replacement URLs are too long for its two-column layout, so each URL now sits on its own line to keep the output inside 80 columns. Same reason for a one-line reflow in `guides/transports.yaml`.
- **`bolt-reference` splits by context.** In `transports.yaml` it documents transport options, so it points at `bolt_transports_reference.html`. In `links.yaml` it was a generic "Reference Documentation" entry; pointing it at the docs root would duplicate the entry above it, so it became "Configuration Reference" → `configuring_bolt.html`.
- **`lib/bolt/analytics.rb` had no valid target.** It pointed at an analytics opt-out page that does not exist in the OpenBolt docs. Analytics are force-disabled in this fork (`config = { 'disabled' => true }`) and the message sat inside `unless ENV['BOLT_DISABLE_ANALYTICS'] || true`, so it was unreachable. The block is removed rather than repointed. Flagging in case anyone wants it kept.
- **openvox-docs** carries the same comment in its sample Puppetfile, but that comes from `lib/bolt/module_installer/puppetfile.rb`, so a docs regen picks this up. No companion PR needed.

## Verification

- Every target URL returns 200, checked live. The anchors — including the three call sites that carry their own (`#modulepath`, `#specify-a-transport`, `#transport-configuration`) — were checked against the rendered heading IDs.
- `rake schemas:all` produces no diff beyond the committed change.
- `rubocop` clean.
- `rspec spec/unit`: 1804 examples, 5 failures. All 5 are in `plugin_spec.rb` / `puppet_library_spec.rb` and fail identically on unmodified `main`, so they are pre-existing and unrelated.
- `bolt guide links` and `bolt guide transports` render correctly.

## Follow-up worth its own issue

Nothing prevents this from recurring the same silent way. A periodic link check over `lib/`, `guides/`, and `schemas/` in CI would have caught it.

Reported by Yury Bushmelev.

## AI usage disclosure

Per the [Vox Pupuli and OpenVox AI Usage Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md): I used Claude Code for this patch — the substitution across all 59 call sites, the live verification of each target URL and anchor, the rubocop/rspec/schema-regen checks reported above, and a first draft of this description. The commit carries a `Co-Authored-By` trailer.

The two spots that most warrant a human eye are called out under "Notes for review": the `bolt-reference` context split, and the analytics block removal, which is the only behavior change here.
