### PR TITLE
Use relative links where the text lands in the docs collection

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -359,7 +359,7 @@ module Bolt
           description: "A list of module dependencies for the project. Each dependency is a map of data specifying " \
                        "the module to install. To install the project's module dependencies, run the `bolt module " \
                        "install` command. For more information about specifying modules, see [the " \
-                       "documentation](https://docs.openvoxproject.org/openbolt/latest/bolt_installing_modules.html#manually-specify-modules-in-a-bolt-project).",
+                       "documentation](bolt_installing_modules.md#manually-specify-modules-in-a-bolt-project).",
           type: Array,
           items: {
             type: [Hash, String],

--- a/lib/bolt/inventory/options.rb
+++ b/lib/bolt/inventory/options.rb
@@ -84,7 +84,7 @@ module Bolt
         "plugin_hooks" => {
           description: "Configuration for the Puppet library plugin used to install the " \
                        "Puppet agent on the target. For more information, see " \
-                       "https://docs.openvoxproject.org/openbolt/latest/writing_plugins.html",
+                       "[plugin hooks](writing_plugins.md#plugin-hooks).",
           type: Hash,
           properties: {
             "puppet_library" => {

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -148,6 +148,16 @@ begin
       $stdout.puts "Generated packaged modules at:\n\t#{filepath}"
     end
 
+    # CLI help text carries full docs URLs, because it is printed to a terminal
+    # where a relative link has nothing to resolve against. Inside the docs
+    # collection the same text must use relative links, so that a locally served
+    # build works offline and a page in an older collection does not silently
+    # follow '/latest/' across a version boundary.
+    docs_url = %r{https://docs\.openvoxproject\.org/openbolt/latest/(\S+?\.html(?:\#[\w-]+)?)}
+    relative_docs_links = lambda do |text|
+      text.gsub(docs_url) { "[#{Regexp.last_match(1)}](#{Regexp.last_match(1)})" }
+    end
+
     desc "Generate markdown docs for Bolt shell commands"
     task :command_reference do
       require 'bolt/bolt_option_parser'
@@ -172,11 +182,11 @@ begin
               short: switch.short.first,
               long: switch.long.first,
               arg: switch.arg,
-              desc: switch.desc.map { |d| d.gsub("<", "&lt;") }.join("<p>")
+              desc: relative_docs_links.call(switch.desc.map { |d| d.gsub("<", "&lt;") }.join("<p>"))
             }
           end
 
-          desc  = matches[:desc].split("\n").map(&:strip).join("\n")
+          desc  = relative_docs_links.call(matches[:desc].split("\n").map(&:strip).join("\n"))
           usage = matches[:usage].strip
 
           @commands[command] = {

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -1854,7 +1854,7 @@
       ]
     },
     "plugin_hooks": {
-      "description": "Configuration for the Puppet library plugin used to install the Puppet agent on the target. For more information, see https://docs.openvoxproject.org/openbolt/latest/writing_plugins.html",
+      "description": "Configuration for the Puppet library plugin used to install the Puppet agent on the target. For more information, see [plugin hooks](writing_plugins.md#plugin-hooks).",
       "oneOf": [
         {
           "type": "object",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -278,7 +278,7 @@
       }
     },
     "modules": {
-      "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command. For more information about specifying modules, see [the documentation](https://docs.openvoxproject.org/openbolt/latest/bolt_installing_modules.html#manually-specify-modules-in-a-bolt-project).",
+      "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command. For more information about specifying modules, see [the documentation](bolt_installing_modules.md#manually-specify-modules-in-a-bolt-project).",
       "type": "array",
       "items": {
         "type": [


### PR DESCRIPTION
Follow-up to #279. That PR merged at its first commit, so the relative-link fix discussed in [this review comment](https://github.com/OpenVoxProject/openbolt/pull/279#issuecomment-5047691912) never landed on `main`. This is that commit, rebased.

@tuxmea raised it on #279: links should be relative so a locally served docs container works offline, without internet access.

Per [openvox-docs CONTRIBUTING § Linking](https://github.com/OpenVoxProject/openvox-docs/blob/master/CONTRIBUTING.md#linking), links within a versioned collection should be bare `page.html` — not rooted `/openbolt/latest/page.html`, since those silently cross version boundaries when a new major collection is added.

The dividing line is whether a string is ever *rendered as a docs page*.

## Relative — rendered into the collection

`lib/bolt/config/options.rb` and `lib/bolt/inventory/options.rb`. These feed the generated reference pages and the JSON schemas, and their siblings were already relative (`projects.md`, `module_structure.md`, `supported_plugins.md#task`), so the absolute URLs #279 introduced were the only ones out of step.

The `.md` form is deliberate: the importer at `lib/puppet_references/openbolt/docs.rb` rewrites relative `.md` → `.html` on the way in.

```ruby
.gsub(/(\]\([^):]*?)\.md((?:#[^)]*)?)\)/, '\1.html\2)')
```

That regex excludes anything containing `:`, which is why absolute URLs passed through untouched and the problem was invisible.

## The dual-purpose case — `bolt_option_parser.rb`

Those strings are printed by `bolt --help`, where a relative link has no base to resolve against, *and* imported as `bolt_command_reference.md` (it is in the importer's `GENERATED_PAGES`). 16 of them land on that page.

Rather than break one context for the other, `rakelib/docs.rake` now rewrites them to relative markdown links while generating that page. Terminal output keeps full URIs; the published page has none.

## Absolute, deliberately — unchanged

Guide output, error messages, and the comments written into generated Puppetfiles and plan templates. None is ever a docs page; a user looking at `plans.html` in a terminal has nothing to resolve it against.

## Verification

- `rake docs:all` → zero absolute docs URLs in any generated page.
- `bolt plan run --help` still prints the full URI.
- `rake schemas:all` reproduces the committed schema JSON exactly.
- `rubocop` clean.
- Anchors verified against openvox-docs.

## AI usage disclosure

Per the [Vox Pupuli and OpenVox AI Usage Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md): I used Claude Code to trace the docs import pipeline, make the change, run the verification above, and draft this description. The commit carries a `Co-Authored-By` trailer.