### PR TITLE
Allow to pass a JSON array/object as a target list to CLI

### DIFF
--- a/guides/targets.yaml
+++ b/guides/targets.yaml
@@ -16,6 +16,8 @@ guide: |
 
     The 'targets' option accepts a comma-separated list of target URIs or group
     names, or can read a target list from an input file '@<file>' or stdin '-'.
+    The input can also be a JSON array of target names or a Bolt result object
+    with an 'items' array where each item has a 'target' key.
     URIs can be specified with the format [protocol://][user@]host[:port]. To
     learn more about available protocols and their defaults, run 'bolt guide
     transports'.

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -675,7 +675,8 @@ module Bolt
     end
 
     # Process the target list by turning a PuppetDB query or rerun mode into a
-    # list of target names.
+    # list of target names. Try to parse each options[:targets] entry as JSON
+    # Array/Hash, return the value as-is if failed.
     #
     # @param plugins [Bolt::Plugin] The Plugin instance.
     # @param rerun [Bolt::Rerun] The Rerun instance.
@@ -688,7 +689,25 @@ module Bolt
       elsif options[:rerun]
         rerun.get_targets(options[:rerun])
       elsif options[:targets]
-        options[:targets]
+        options[:targets].map do |target|
+          parsed = JSON.parse(target)
+          case parsed
+          when Array
+            parsed
+          when Hash
+            items = parsed['items']
+            if items.is_a?(Array)
+              items.map { |item| item['target'] }
+            else
+              raise Bolt::Error.new("Expected a JSON array or an object with an 'items' array, got #{parsed.class}",
+                                    'bolt/invalid-targets')
+            end
+          else
+            target
+          end
+        rescue JSON::ParserError
+          target
+        end
       end
     end
 

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -606,6 +606,36 @@ describe Bolt::CLI do
       end
     end
 
+    describe 'target processing' do
+      let(:options) { { subcommand: 'command', action: 'run', object: 'whoami', targets: targets } }
+
+      it 'parses a JSON array from targets' do
+        expect(application).to receive(:run_command).with(anything, [%w[host1 host2]])
+        cli.execute({ subcommand: 'command', action: 'run', object: 'whoami',
+                      targets: ['["host1","host2"]'] })
+      end
+
+      it 'parses a bolt result JSON with items' do
+        expect(application).to receive(:run_command)
+          .with(anything, [%w[host1 host2]])
+        cli.execute({ subcommand: 'command', action: 'run', object: 'whoami',
+                      targets: ['{"items":[{"target":"host1"},{"target":"host2"}]}'] })
+      end
+
+      it 'passes unrecognized JSON through as raw string' do
+        expect(application).to receive(:run_command).with(anything, ['42'])
+        cli.execute({ subcommand: 'command', action: 'run', object: 'whoami',
+                      targets: ['42'] })
+      end
+
+      it 'errors when JSON is an object without items' do
+        expect do
+          cli.execute({ subcommand: 'command', action: 'run', object: 'whoami',
+                        targets: ['{"foo":"bar"}'] })
+        end.to raise_error(Bolt::Error, /Expected a JSON array or an object/)
+      end
+    end
+
     describe 'bundled content' do
       before(:each) do
         allow(pal).to receive(:list_plans).and_return([%w[plan description]])


### PR DESCRIPTION
### Short description
This PR expands formats, bolt CLI can accept from command line. Now JSON array of target names and JSON object of target items (`{"items": [{"target": "target"}, ...]}` is supported. This allows to pass a `bolt ... run ... --format=json` output to another bolt invocation as a target list (`bolt ... run -t- ...` e.g.)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
